### PR TITLE
Increase log import limit to 256 MB

### DIFF
--- a/Scalemon.ApiService/Controllers/LogsController.cs
+++ b/Scalemon.ApiService/Controllers/LogsController.cs
@@ -205,8 +205,11 @@ public sealed class LogsController : ControllerBase
     // -----------------------------------------------------------------------
     // ИМПОРТ ТЕКСТОВОГО ЛОГА В SQLite
     // POST /api/logs/import
+    private const long MaxLogImportSizeBytes = 256L * 1024 * 1024;
+
     [HttpPost("import")]
-    [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = long.MaxValue)]
+    [RequestSizeLimit(MaxLogImportSizeBytes)]
+    [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = MaxLogImportSizeBytes)]
     public async Task<IActionResult> Import([FromForm] List<IFormFile> files, [FromForm] List<string>? fileNames)
     {
         if (files is null || files.Count == 0)

--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,10 +31,22 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
 
+const long LogUploadLimitBytes = 256L * 1024 * 1024;
+
 // --- 1. СОЗДАНИЕ УНИВЕРСАЛЬНОГО ПОСТРОИТЕЛЯ ПРИЛОЖЕНИЯ ---
 // WebApplication.CreateBuilder подходит и для служб, и для веб-серверов.
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = LogUploadLimitBytes;
+});
+
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = LogUploadLimitBytes;
+});
 
 var logDatabaseProvider = new DailyLogDatabaseProvider(config["Logging:Database:MainDatabasePath"]);
 logDatabaseProvider.EnsureCurrentDatabase();

--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -156,7 +156,7 @@
 
     private CancellationTokenSource _cts = new();
     private InputFile? _importInput;
-    private const long MaxImportFileSize = 512L * 1024 * 1024;
+    private const long MaxImportFileSize = 256L * 1024 * 1024;
   
 
     // Auto refresh


### PR DESCRIPTION
## Summary
- set the Blazor log import component to allow uploads up to 256 MB
- enforce the same 256 MB limit in the API controller for log imports
- configure the host to accept 256 MB multipart requests via Kestrel and form options

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2271e4a84832f88833c545a813c89