### PR TITLE
Implement SQLite-backed authentication service

### DIFF
--- a/Scalemon.Common/Auth/AuthContracts.cs
+++ b/Scalemon.Common/Auth/AuthContracts.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Scalemon.Common.Auth;
+
+public interface IAuthService
+{
+    Task<AuthValidationResult> ValidateAsync(string login, string password);
+}
+
+public sealed record AuthValidationResult(bool Ok, IReadOnlyCollection<string> Roles, string? DisplayName);
+
+public sealed record UserRecord(string Login, string DisplayName, IReadOnlyCollection<string> Roles);
+
+public interface IUsersStore
+{
+    IReadOnlyCollection<UserRecord> List();
+    bool TryAdd(string login, string password, string displayName, IReadOnlyCollection<string> roles);
+    bool TryUpdate(string login, string? password, string? displayName, IReadOnlyCollection<string>? roles);
+    bool Remove(string login);
+}

--- a/Scalemon.Common/Auth/InMemoryAuthService.cs
+++ b/Scalemon.Common/Auth/InMemoryAuthService.cs
@@ -1,30 +1,16 @@
-﻿// using System.Collections.Concurrent;
-// using System.Text.Json;
-
 using Microsoft.Extensions.Options;
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.Json;
 
 namespace Scalemon.Common.Auth
 {
-    public interface IAuthService
-    {
-        Task<(bool ok, string? role)> ValidateAsync(string login, string password);
-    }
-
-    public record UserRecord(string Login, string Role);
-
-    public interface IUsersStore
-    {
-        IReadOnlyCollection<UserRecord> List();
-        bool TryAdd(string login, string password, string role);
-        bool TryUpdate(string login, string? password, string? role);
-        bool Remove(string login);
-    }
-
     public sealed class InMemoryAuthService : IAuthService, IUsersStore
     {
-        private readonly ConcurrentDictionary<string, (string pass, string role)> _users;
+        private readonly ConcurrentDictionary<string, (string pass, string displayName, string[] roles)> _users;
         private readonly string? _filePath;
         private readonly object _io = new();
 
@@ -32,38 +18,46 @@ namespace Scalemon.Common.Auth
         {
             _filePath = opt.Value.Authentication?.UsersFilePath;
             _users = Load(_filePath)
-                ?? new ConcurrentDictionary<string, (string pass, string role)>(
+                ?? new ConcurrentDictionary<string, (string pass, string displayName, string[] roles)>(
                     new[]
                     {
-                        new KeyValuePair<string,(string,string)>("viewer", ("viewer123","Viewer")),
-                        new KeyValuePair<string,(string,string)>("editor", ("<ehuek.r","Editor")),
-                        new KeyValuePair<string,(string,string)>("admin",  ("1<ehuek.r","Admin")),
+                        new KeyValuePair<string,(string,string,string[])>("viewer", ("viewer123","Viewer", new[]{"Viewer"})),
+                        new KeyValuePair<string,(string,string,string[])>("editor", ("<ehuek.r","Editor", new[]{"Editor"})),
+                        new KeyValuePair<string,(string,string,string[])>("admin",  ("1<ehuek.r","Administrator", new[]{"Admin"})),
                     },
                     StringComparer.OrdinalIgnoreCase);
         }
 
-        public Task<(bool ok, string? role)> ValidateAsync(string login, string password) =>
-            Task.FromResult(_users.TryGetValue(login, out var u) && u.pass == password
-                ? (true, u.role)
-                : (false, null));
+        public Task<AuthValidationResult> ValidateAsync(string login, string password)
+        {
+            if (_users.TryGetValue(login, out var u) && u.pass == password)
+            {
+                return Task.FromResult(new AuthValidationResult(true, u.roles, u.displayName));
+            }
 
-        // --- IUsersStore ---
+            return Task.FromResult(new AuthValidationResult(false, Array.Empty<string>(), null));
+        }
+
         public IReadOnlyCollection<UserRecord> List() =>
-            _users.Select(kv => new UserRecord(kv.Key, kv.Value.role))
+            _users.Select(kv => new UserRecord(kv.Key, kv.Value.displayName, kv.Value.roles))
                   .OrderBy(u => u.Login, StringComparer.OrdinalIgnoreCase)
                   .ToArray();
 
-        public bool TryAdd(string login, string password, string role)
+        public bool TryAdd(string login, string password, string displayName, IReadOnlyCollection<string> roles)
         {
-            var ok = _users.TryAdd(login, (password, role));
+            var normalizedRoles = NormalizeRoles(roles);
+            var ok = _users.TryAdd(login, (password, string.IsNullOrWhiteSpace(displayName) ? login : displayName, normalizedRoles));
             if (ok) Save();
             return ok;
         }
 
-        public bool TryUpdate(string login, string? password, string? role)
+        public bool TryUpdate(string login, string? password, string? displayName, IReadOnlyCollection<string>? roles)
         {
             if (!_users.TryGetValue(login, out var cur)) return false;
-            _users[login] = (password ?? cur.pass, role ?? cur.role);
+            var normalizedRoles = roles is null ? cur.roles : NormalizeRoles(roles, cur.roles);
+            _users[login] = (password ?? cur.pass,
+                             string.IsNullOrWhiteSpace(displayName) ? cur.displayName : displayName!,
+                             normalizedRoles);
             Save();
             return true;
         }
@@ -80,24 +74,49 @@ namespace Scalemon.Common.Auth
             if (string.IsNullOrWhiteSpace(_filePath)) return;
             lock (_io)
             {
-                var payload = _users.Select(kv => new UserFile { login = kv.Key, password = kv.Value.pass, role = kv.Value.role });
+                var payload = _users.Select(kv => new UserFile
+                {
+                    login = kv.Key,
+                    password = kv.Value.pass,
+                    displayName = kv.Value.displayName,
+                    roles = kv.Value.roles,
+                });
                 File.WriteAllText(_filePath, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
             }
         }
 
-        private static ConcurrentDictionary<string, (string pass, string role)>? Load(string? path)
+        private static ConcurrentDictionary<string, (string pass, string displayName, string[] roles)>? Load(string? path)
         {
             try
             {
                 if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return null;
                 var arr = JsonSerializer.Deserialize<List<UserFile>>(File.ReadAllText(path)) ?? new();
-                return new ConcurrentDictionary<string, (string, string)>(
-                    arr.Select(i => new KeyValuePair<string, (string, string)>(i.login, (i.password, i.role))),
+                return new ConcurrentDictionary<string, (string, string, string[])>(
+                    arr.Select(i => new KeyValuePair<string, (string, string, string[])>(
+                        i.login,
+                        (i.password,
+                         string.IsNullOrWhiteSpace(i.displayName) ? i.login : i.displayName!,
+                         NormalizeRoles(i.roles)))),
                     StringComparer.OrdinalIgnoreCase);
             }
             catch { return null; }
         }
 
-        private sealed class UserFile { public string login { get; set; } = ""; public string password { get; set; } = ""; public string role { get; set; } = "Viewer"; }
+        private static string[] NormalizeRoles(IEnumerable<string>? roles, string[]? fallback = null)
+        {
+            var normalized = roles?.Where(r => !string.IsNullOrWhiteSpace(r))
+                                   .Select(r => r.Trim())
+                                   .Distinct(StringComparer.OrdinalIgnoreCase)
+                                   .ToArray();
+            return normalized is { Length: > 0 } ? normalized : fallback ?? Array.Empty<string>();
+        }
+
+        private sealed class UserFile
+        {
+            public string login { get; set; } = "";
+            public string password { get; set; } = "";
+            public string? displayName { get; set; }
+            public string[]? roles { get; set; }
+        }
     }
 }

--- a/Scalemon.Common/Auth/SqliteAuthService.cs
+++ b/Scalemon.Common/Auth/SqliteAuthService.cs
@@ -1,0 +1,335 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+
+namespace Scalemon.Common.Auth;
+
+public sealed class SqliteAuthService : IAuthService, IUsersStore
+{
+    private const int SaltSize = 16;
+    private const int HashSize = 32;
+    private const int Iterations = 100_000;
+
+    private readonly ILogger<SqliteAuthService> _logger;
+    private readonly string _connectionString;
+    private readonly AuthenticationSettings _settings;
+    private readonly object _initLock = new();
+    private bool _initialized;
+
+    public SqliteAuthService(IOptions<ServiceSettings> options, ILogger<SqliteAuthService> logger)
+    {
+        _settings = options.Value.Authentication ?? new AuthenticationSettings();
+        _logger = logger;
+
+        var path = _settings.UsersDatabasePath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = Path.Combine(AppContext.BaseDirectory, "users.db");
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = path, ForeignKeys = true }.ToString();
+    }
+
+    public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureInitialized();
+        return Task.CompletedTask;
+    }
+
+    public async Task<AuthValidationResult> ValidateAsync(string login, string password)
+    {
+        EnsureInitialized();
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT password_hash, salt, roles, display_name FROM users WHERE login = $login";
+        command.Parameters.AddWithValue("$login", login);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return new AuthValidationResult(false, Array.Empty<string>(), null);
+        }
+
+        var storedHash = reader.GetString(0);
+        var salt = reader.GetString(1);
+        var rolesJson = reader.GetString(2);
+        var displayName = reader.GetString(3);
+
+        if (!VerifyPassword(password, storedHash, salt))
+        {
+            return new AuthValidationResult(false, Array.Empty<string>(), null);
+        }
+
+        var roles = DeserializeRoles(rolesJson);
+        return new AuthValidationResult(true, roles, displayName);
+    }
+
+    public IReadOnlyCollection<UserRecord> List()
+    {
+        EnsureInitialized();
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT login, display_name, roles FROM users ORDER BY login COLLATE NOCASE";
+
+        using var reader = command.ExecuteReader();
+        var users = new List<UserRecord>();
+        while (reader.Read())
+        {
+            var login = reader.GetString(0);
+            var displayName = reader.GetString(1);
+            var roles = DeserializeRoles(reader.GetString(2));
+            users.Add(new UserRecord(login, displayName, roles));
+        }
+
+        return users;
+    }
+
+    public bool TryAdd(string login, string password, string displayName, IReadOnlyCollection<string> roles)
+    {
+        EnsureInitialized();
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        using var check = connection.CreateCommand();
+        check.CommandText = "SELECT COUNT(1) FROM users WHERE login = $login";
+        check.Parameters.AddWithValue("$login", login);
+        var exists = Convert.ToInt64(check.ExecuteScalar()) > 0;
+        if (exists)
+        {
+            return false;
+        }
+
+        var salt = GenerateSalt();
+        var hash = HashPassword(password, salt);
+        var now = DateTimeOffset.UtcNow;
+        var display = string.IsNullOrWhiteSpace(displayName) ? login : displayName;
+        var rolesJson = SerializeRoles(roles);
+
+        using var insert = connection.CreateCommand();
+        insert.CommandText = @"INSERT INTO users (login, password_hash, salt, roles, display_name, created_at, updated_at)
+                               VALUES ($login, $hash, $salt, $roles, $displayName, $created, NULL)";
+        insert.Parameters.AddWithValue("$login", login);
+        insert.Parameters.AddWithValue("$hash", hash);
+        insert.Parameters.AddWithValue("$salt", salt);
+        insert.Parameters.AddWithValue("$roles", rolesJson);
+        insert.Parameters.AddWithValue("$displayName", display);
+        insert.Parameters.AddWithValue("$created", now.UtcDateTime.ToString("O"));
+
+        return insert.ExecuteNonQuery() > 0;
+    }
+
+    public bool TryUpdate(string login, string? password, string? displayName, IReadOnlyCollection<string>? roles)
+    {
+        EnsureInitialized();
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        using var select = connection.CreateCommand();
+        select.CommandText = "SELECT password_hash, salt, roles, display_name FROM users WHERE login = $login";
+        select.Parameters.AddWithValue("$login", login);
+
+        using var reader = select.ExecuteReader();
+        if (!reader.Read())
+        {
+            return false;
+        }
+
+        var currentHash = reader.GetString(0);
+        var currentSalt = reader.GetString(1);
+        var currentRoles = reader.GetString(2);
+        var currentDisplay = reader.GetString(3);
+
+        reader.Close();
+
+        var newSalt = currentSalt;
+        var newHash = currentHash;
+        if (!string.IsNullOrEmpty(password))
+        {
+            newSalt = GenerateSalt();
+            newHash = HashPassword(password, newSalt);
+        }
+
+        var newRolesJson = roles is null ? currentRoles : SerializeRoles(roles);
+        var newDisplay = string.IsNullOrWhiteSpace(displayName) ? currentDisplay : displayName!;
+        var now = DateTimeOffset.UtcNow;
+
+        using var update = connection.CreateCommand();
+        update.CommandText = @"UPDATE users
+                                SET password_hash = $hash,
+                                    salt = $salt,
+                                    roles = $roles,
+                                    display_name = $display,
+                                    updated_at = $updated
+                                WHERE login = $login";
+        update.Parameters.AddWithValue("$hash", newHash);
+        update.Parameters.AddWithValue("$salt", newSalt);
+        update.Parameters.AddWithValue("$roles", newRolesJson);
+        update.Parameters.AddWithValue("$display", newDisplay);
+        update.Parameters.AddWithValue("$updated", now.UtcDateTime.ToString("O"));
+        update.Parameters.AddWithValue("$login", login);
+
+        return update.ExecuteNonQuery() > 0;
+    }
+
+    public bool Remove(string login)
+    {
+        EnsureInitialized();
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        using var delete = connection.CreateCommand();
+        delete.CommandText = "DELETE FROM users WHERE login = $login";
+        delete.Parameters.AddWithValue("$login", login);
+
+        return delete.ExecuteNonQuery() > 0;
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        lock (_initLock)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = @"CREATE TABLE IF NOT EXISTS users (
+                                        login TEXT PRIMARY KEY,
+                                        password_hash TEXT NOT NULL,
+                                        salt TEXT NOT NULL,
+                                        roles TEXT NOT NULL,
+                                        display_name TEXT NOT NULL,
+                                        created_at TEXT NOT NULL,
+                                        updated_at TEXT
+                                    );";
+                command.ExecuteNonQuery();
+            }
+
+            EnsureInitialAdmin(connection);
+            _initialized = true;
+        }
+    }
+
+    private void EnsureInitialAdmin(SqliteConnection connection)
+    {
+        var admin = _settings.InitialAdmin;
+        if (admin is null || string.IsNullOrWhiteSpace(admin.Login) || string.IsNullOrEmpty(admin.Password))
+        {
+            return;
+        }
+
+        using var check = connection.CreateCommand();
+        check.CommandText = "SELECT COUNT(1) FROM users WHERE login = $login";
+        check.Parameters.AddWithValue("$login", admin.Login);
+        var exists = Convert.ToInt64(check.ExecuteScalar()) > 0;
+        if (exists)
+        {
+            return;
+        }
+
+        var salt = GenerateSalt();
+        var hash = HashPassword(admin.Password, salt);
+        var now = DateTimeOffset.UtcNow;
+        var roles = SerializeRoles(admin.Roles?.Length > 0 ? admin.Roles : new[] { "Admin" });
+        var display = string.IsNullOrWhiteSpace(admin.DisplayName) ? admin.Login : admin.DisplayName;
+
+        using var insert = connection.CreateCommand();
+        insert.CommandText = @"INSERT INTO users (login, password_hash, salt, roles, display_name, created_at, updated_at)
+                               VALUES ($login, $hash, $salt, $roles, $displayName, $created, NULL)";
+        insert.Parameters.AddWithValue("$login", admin.Login);
+        insert.Parameters.AddWithValue("$hash", hash);
+        insert.Parameters.AddWithValue("$salt", salt);
+        insert.Parameters.AddWithValue("$roles", roles);
+        insert.Parameters.AddWithValue("$displayName", display);
+        insert.Parameters.AddWithValue("$created", now.UtcDateTime.ToString("O"));
+        insert.ExecuteNonQuery();
+
+        _logger.LogInformation("Initial admin user '{Login}' created in authentication database", admin.Login);
+    }
+
+    private static string GenerateSalt()
+    {
+        var salt = new byte[SaltSize];
+        RandomNumberGenerator.Fill(salt);
+        return Convert.ToBase64String(salt);
+    }
+
+    private static string HashPassword(string password, string salt)
+    {
+        var saltBytes = Convert.FromBase64String(salt);
+        using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+        return Convert.ToBase64String(pbkdf2.GetBytes(HashSize));
+    }
+
+    private static bool VerifyPassword(string password, string storedHash, string salt)
+    {
+        try
+        {
+            var computed = HashPassword(password, salt);
+            return CryptographicOperations.FixedTimeEquals(
+                Convert.FromBase64String(storedHash),
+                Convert.FromBase64String(computed));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string SerializeRoles(IReadOnlyCollection<string>? roles)
+    {
+        var normalized = roles?.Where(r => !string.IsNullOrWhiteSpace(r))
+                               .Select(r => r.Trim())
+                               .Distinct(StringComparer.OrdinalIgnoreCase)
+                               .ToArray() ?? Array.Empty<string>();
+        return JsonSerializer.Serialize(normalized);
+    }
+
+    private static string[] DeserializeRoles(string json)
+    {
+        try
+        {
+            var roles = JsonSerializer.Deserialize<string[]>(json) ?? Array.Empty<string>();
+            return roles.Where(r => !string.IsNullOrWhiteSpace(r))
+                        .Select(r => r.Trim())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/Scalemon.Common/ServiceSettings.cs
+++ b/Scalemon.Common/ServiceSettings.cs
@@ -26,6 +26,17 @@
     {
         public BasicAuthSettings Basic { get; set; } = new BasicAuthSettings();
         public string? UsersFilePath { get; set; }  // ← новое поле
+        public string? UsersDatabasePath { get; set; }
+        public int? SessionTimeoutMinutes { get; set; }
+        public InitialAdminSettings InitialAdmin { get; set; } = new InitialAdminSettings();
+    }
+
+    public class InitialAdminSettings
+    {
+        public string Login { get; set; } = "admin";
+        public string Password { get; set; } = "ChangeMe!";
+        public string DisplayName { get; set; } = "Administrator";
+        public string[] Roles { get; set; } = new[] { "Admin" };
     }
 
     public class BasicAuthSettings

--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -26,6 +26,7 @@ using Scalemon.ServiceHost.Logging;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -92,8 +93,6 @@ builder.Services.AddSingleton<IScaleProcessor>(sp =>
         settings.StableThreshold, settings.UnstableThreshold, settings.PollingIntervalMs);
 });
 
-builder.Services.AddSingleton<IAuthService, InMemoryAuthService>();
-
 builder.Services.AddSingleton<IDataAccess>(sp =>
 {
     var settings = sp.GetRequiredService<IOptions<ServiceSettings>>().Value.DatabaseSettings;
@@ -137,9 +136,9 @@ builder.Services.AddSingleton<IScaleStateMachine>(sp =>
 builder.Services.AddHostedService<ScalemonService>();
 
 // Добавляем сервис аутентификации для WebApp
-builder.Services.AddSingleton<IAuthService, InMemoryAuthService>();
-
-builder.Services.AddSingleton<IUsersStore>(sp => sp.GetRequiredService<InMemoryAuthService>());
+builder.Services.AddSingleton<SqliteAuthService>();
+builder.Services.AddSingleton<IAuthService>(sp => sp.GetRequiredService<SqliteAuthService>());
+builder.Services.AddSingleton<IUsersStore>(sp => sp.GetRequiredService<SqliteAuthService>());
 
 
 
@@ -149,12 +148,16 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Аутентификация через Cookies для веб-интерфейса
+var sessionTimeoutMinutes = config.GetValue<int?>("Authentication:SessionTimeoutMinutes");
+
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>
     {
         options.Cookie.Name = "ScalemonAuth";
-        options.ExpireTimeSpan = TimeSpan.FromHours(8);
         options.SlidingExpiration = true;
+        options.ExpireTimeSpan = sessionTimeoutMinutes is > 0
+            ? TimeSpan.FromMinutes(sessionTimeoutMinutes.Value)
+            : TimeSpan.FromHours(8);
         options.Events.OnRedirectToLogin = context =>
         {
             if (context.Request.Path.StartsWithSegments("/api"))
@@ -229,6 +232,8 @@ builder.Host.UseWindowsService();
 // --- 4. ПОСТРОЕНИЕ И КОНФИГУРАЦИЯ КОНВЕЙЕРА HTTP-ЗАПРОСОВ ---
 var app = builder.Build();
 
+await app.Services.GetRequiredService<SqliteAuthService>().EnsureInitializedAsync();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
@@ -251,14 +256,24 @@ app.MapControllers();
 
 app.MapPost("/api/auth/login", async (HttpContext http, [FromBody] AuthController.LoginModel model, [FromServices] IAuthService authService) =>
 {
-    var (isValid, role) = await authService.ValidateAsync(model.Username, model.Password);
-    if (isValid)
+    var validation = await authService.ValidateAsync(model.Username, model.Password);
+    if (validation.Ok)
     {
         var claims = new List<Claim>
         {
-            new Claim(ClaimTypes.Name, model.Username),
-            new Claim(ClaimTypes.Role, role!) // Добавляем роль пользователя
+            new Claim(ClaimTypes.Name, model.Username)
         };
+
+        if (!string.IsNullOrWhiteSpace(validation.DisplayName))
+        {
+            claims.Add(new Claim(ClaimTypes.GivenName, validation.DisplayName!));
+        }
+
+        foreach (var role in validation.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
         var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
         var principal = new ClaimsPrincipal(identity);
         await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
@@ -283,17 +298,28 @@ users.MapPost("/", (IUsersStore store, UserUpsert dto) =>
 {
     if (string.IsNullOrWhiteSpace(dto.Login) ||
         string.IsNullOrWhiteSpace(dto.Password) ||
-        string.IsNullOrWhiteSpace(dto.Role))
-        return Results.BadRequest("login/password/role required");
+        dto.Roles is null)
+    {
+        return Results.BadRequest("login/password/roles required");
+    }
 
-    return store.TryAdd(dto.Login, dto.Password, dto.Role)
+    var roles = dto.Roles.Where(r => !string.IsNullOrWhiteSpace(r))
+                         .Select(r => r.Trim())
+                         .Distinct(StringComparer.OrdinalIgnoreCase)
+                         .ToArray();
+    if (roles.Length == 0)
+    {
+        return Results.BadRequest("At least one role required");
+    }
+
+    return store.TryAdd(dto.Login, dto.Password, dto.DisplayName, roles)
         ? Results.Created($"/api/auth/users/{dto.Login}", null)
         : Results.Conflict("User exists");
 }).DisableAntiforgery();
 
 users.MapPut("/{login}", (IUsersStore store, string login, UserUpdate dto) =>
 {
-    return store.TryUpdate(login, dto.Password, dto.Role)
+    return store.TryUpdate(login, dto.Password, dto.DisplayName, dto.Roles)
         ? Results.NoContent()
         : Results.NotFound();
 }).DisableAntiforgery();
@@ -313,6 +339,18 @@ app.MapRazorComponents<App>()
 // --- 5. ЗАПУСК ПРИЛОЖЕНИЯ ---
 app.Run();
 
-public sealed record UserUpsert(string Login, string Password, string Role);
-public sealed record UserUpdate(string? Password, string? Role);
+public sealed record UserUpsert
+{
+    public string Login { get; init; } = string.Empty;
+    public string Password { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public List<string> Roles { get; init; } = new();
+}
+
+public sealed record UserUpdate
+{
+    public string? Password { get; init; }
+    public string? DisplayName { get; init; }
+    public List<string>? Roles { get; init; }
+}
 

--- a/Scalemon.ServiceHost/appsettings.json
+++ b/Scalemon.ServiceHost/appsettings.json
@@ -10,7 +10,14 @@
       "Username": "scalemon_api",
       "Password": "секрет"
     },
-    "UsersFilePath": "C:\\Scalemon\\users.json"
+    "UsersDatabasePath": "C:\\Scalemon\\users.db",
+    "SessionTimeoutMinutes": 480,
+    "InitialAdmin": {
+      "Login": "admin",
+      "Password": "ChangeMe!123",
+      "DisplayName": "System Administrator",
+      "Roles": [ "Admin" ]
+    }
   },
   "Logging": {
     "Level": {

--- a/Scalemon.Tests/Scalemon.Tests.csproj
+++ b/Scalemon.Tests/Scalemon.Tests.csproj
@@ -20,4 +20,7 @@
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Scalemon.Common\Scalemon.Common.csproj" />
+  </ItemGroup>
 </Project>

--- a/Scalemon.Tests/UnitTest1.cs
+++ b/Scalemon.Tests/UnitTest1.cs
@@ -1,22 +1,107 @@
-﻿using NUnit.Framework;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Scalemon.Common;
+using Scalemon.Common.Auth;
+using System;
+using System.IO;
+using System.Linq;
 
-namespace Scalemon.Tests.Scalemon.Tests
+namespace Scalemon.Tests.Auth;
+
+[TestFixture]
+public class SqliteAuthServiceTests
 {
+    private string _databasePath = null!;
+    private SqliteAuthService _service = null!;
 
-    public class Tests
+    [SetUp]
+    public void SetUp()
     {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"scalemon_users_{Guid.NewGuid():N}.db");
 
-        [SetUp]
-        public void Setup()
+        var settings = new ServiceSettings
         {
-        }
+            Authentication = new AuthenticationSettings
+            {
+                UsersDatabasePath = _databasePath,
+                InitialAdmin = new InitialAdminSettings
+                {
+                    Login = "seedAdmin",
+                    Password = "Admin123!",
+                    DisplayName = "Seed Admin",
+                    Roles = new[] { "Admin" }
+                }
+            }
+        };
 
-        [Test]
-        public void Test1()
-        {
-            Assert.Pass();
-        }
-
+        _service = new SqliteAuthService(Options.Create(settings), NullLogger<SqliteAuthService>.Instance);
+        _service.EnsureInitializedAsync().GetAwaiter().GetResult();
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        if (File.Exists(_databasePath))
+        {
+            try
+            {
+                File.Delete(_databasePath);
+            }
+            catch
+            {
+                // ignore cleanup errors
+            }
+        }
+    }
+
+    [Test]
+    public async Task ValidateAsync_ReturnsSeedAdmin()
+    {
+        var result = await _service.ValidateAsync("seedAdmin", "Admin123!");
+        Assert.That(result.Ok, Is.True);
+        Assert.That(result.Roles, Does.Contain("Admin"));
+        Assert.That(result.DisplayName, Is.EqualTo("Seed Admin"));
+    }
+
+    [Test]
+    public void TryAdd_CreatesUserAndAllowsAuthentication()
+    {
+        var added = _service.TryAdd("user1", "Password!1", "User One", new[] { "Viewer", "Editor" });
+        Assert.That(added, Is.True);
+
+        var validation = _service.ValidateAsync("user1", "Password!1").GetAwaiter().GetResult();
+        Assert.That(validation.Ok, Is.True);
+        Assert.That(validation.Roles, Is.EquivalentTo(new[] { "Viewer", "Editor" }));
+        Assert.That(validation.DisplayName, Is.EqualTo("User One"));
+    }
+
+    [Test]
+    public void TryUpdate_ChangesPasswordDisplayNameAndRoles()
+    {
+        _service.TryAdd("user2", "InitialPass!", "Initial", new[] { "Viewer" });
+
+        var updated = _service.TryUpdate("user2", "NewPass#1", "Updated User", new[] { "Editor", "Admin" });
+        Assert.That(updated, Is.True);
+
+        var oldValidation = _service.ValidateAsync("user2", "InitialPass!").GetAwaiter().GetResult();
+        Assert.That(oldValidation.Ok, Is.False);
+
+        var newValidation = _service.ValidateAsync("user2", "NewPass#1").GetAwaiter().GetResult();
+        Assert.That(newValidation.Ok, Is.True);
+        Assert.That(newValidation.Roles, Is.EquivalentTo(new[] { "Editor", "Admin" }));
+        Assert.That(newValidation.DisplayName, Is.EqualTo("Updated User"));
+    }
+
+    [Test]
+    public void Remove_DeletesUser()
+    {
+        _service.TryAdd("user3", "Pass@123", "ToRemove", new[] { "Viewer" });
+        var removed = _service.Remove("user3");
+        Assert.That(removed, Is.True);
+
+        var users = _service.List();
+        Assert.That(users.Any(u => u.Login.Equals("user3", StringComparison.OrdinalIgnoreCase)), Is.False);
+    }
 }
+


### PR DESCRIPTION
## Summary
- add authentication configuration for SQLite storage, session timeout, and initial admin seeding
- replace the in-memory authentication wiring with a SQLite implementation and expose display name plus roles via the API
- extend user management endpoints and add unit tests that cover create, update, delete, and validation workflows

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e388904a14832f9a46bdedf808b72a