### PR TITLE
Use typed dialog result for user editor

### DIFF
--- a/Scalemon.WebApp/Components/Pages/SettingsUsersTab.razor
+++ b/Scalemon.WebApp/Components/Pages/SettingsUsersTab.razor
@@ -241,9 +241,9 @@
             ? DialogTitleForNewUser
             : string.Format(CultureInfo.CurrentCulture, DialogTitleForExistingUserFormat, model.Login);
 
-        var result = await DialogService.OpenAsync<UserEditorDialog>(
+        var result = await DialogService.OpenAsync<UserEditorDialog, UserEditModel?>(
             title,
-            new Dictionary<string, object?>
+            new Dictionary<string, object>
             {
                 [nameof(UserEditorDialog.Model)] = model,
                 [nameof(UserEditorDialog.IsNew)] = isNew,
@@ -251,7 +251,7 @@
             },
             new DialogOptions { CloseDialogOnOverlayClick = false, Width = "480px" });
 
-        return result as UserEditModel;
+        return result;
     }
 
     private async Task ExecuteWithLoadingAsync(Func<CancellationToken, Task> action)


### PR DESCRIPTION
## Summary
- request the dialog result as a UserEditModel from DialogService.OpenAsync and drop the manual cast

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fd67b920832fbfd0e3c1ece00a3f