### PR TITLE
Fix log preview dialog builder invocation

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -525,7 +525,7 @@
         var path = Model.LogSettings.FilePath?.MainLogPath;
         var items = (await Api.GetLogPreviewAsync(path, _cts?.Token ?? default)).ToList();
 
-        await DialogService.OpenAsync("Журнал событий", ds => (builder) =>
+        await DialogService.OpenAsync("Журнал событий", builder =>
         {
             builder.OpenComponent(0, typeof(RadzenDataGrid<ApiClient.LogEntry>));
             builder.AddAttribute(1, "Data", items);

--- a/Scalemon.WebApp/Components/Pages/SettingsUsersTab.razor
+++ b/Scalemon.WebApp/Components/Pages/SettingsUsersTab.razor
@@ -241,9 +241,9 @@
             ? DialogTitleForNewUser
             : string.Format(CultureInfo.CurrentCulture, DialogTitleForExistingUserFormat, model.Login);
 
-        var result = await DialogService.OpenAsync<UserEditorDialog, UserEditModel?>(
+        var result = await DialogService.OpenAsync<UserEditorDialog>(
             title,
-            new Dictionary<string, object>
+            new Dictionary<string, object?>
             {
                 [nameof(UserEditorDialog.Model)] = model,
                 [nameof(UserEditorDialog.IsNew)] = isNew,
@@ -251,7 +251,7 @@
             },
             new DialogOptions { CloseDialogOnOverlayClick = false, Width = "480px" });
 
-        return result;
+        return result as UserEditModel;
     }
 
     private async Task ExecuteWithLoadingAsync(Func<CancellationToken, Task> action)


### PR DESCRIPTION
## Summary
- correct the log preview dialog to pass a render fragment builder directly to DialogService.OpenAsync so the grid content renders without compile errors

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e40f4dfe44832f81106c01313a6d9c