### PR TITLE
Fix user list mapping in settings page

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -11,6 +11,7 @@
 
 
 @attribute [Authorize(Policy = "AdminOnly")]
+@implements IDisposable
 
 @inject ApiClient Api
 @inject DialogService DialogService
@@ -626,7 +627,7 @@
             _usersLoading = true;
             var users = await Api.GetUsersAsync(ct);
             Users = users
-                .Select(UserListItem.FromRecord)
+                .Select(UserListItem.FromSummary)
                 .OrderBy(u => u.Login, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }

--- a/Scalemon.WebApp/Models/UserModels.cs
+++ b/Scalemon.WebApp/Models/UserModels.cs
@@ -16,6 +16,13 @@ public sealed class UserListItem
         DisplayName = record.DisplayName,
         Roles = record.Roles?.ToList() ?? new List<string>()
     };
+
+    public static UserListItem FromSummary(ApiClient.UserSummary summary) => new()
+    {
+        Login = summary.Login,
+        DisplayName = summary.DisplayName,
+        Roles = summary.Roles?.ToList() ?? new List<string>()
+    };
 }
 
 public sealed class UserEditModel


### PR DESCRIPTION
## Summary
- map API user summaries to the settings page user list so the grid receives the correct model type
- add a helper on `UserListItem` to convert from API summaries

## Testing
- Not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e46e795558832f98054aa05010e895