### PR TITLE
Forward auth cookies to ApiClient requests

### DIFF
--- a/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
+++ b/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Scalemon.ServiceHost.Http;
+
+public class ForwardAuthCookiesHandler : DelegatingHandler
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ForwardAuthCookiesHandler(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var cookieHeader = _httpContextAccessor.HttpContext?.Request?.Headers[HeaderNames.Cookie];
+
+        if (!StringValues.IsNullOrEmpty(cookieHeader))
+        {
+            request.Headers.Remove(HeaderNames.Cookie);
+
+            foreach (var value in cookieHeader)
+            {
+                if (CookieHeaderValue.TryParse(value, out var cookie))
+                {
+                    request.Headers.Cookie.Add(cookie);
+                }
+                else
+                {
+                    request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, value);
+                }
+            }
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -22,6 +22,7 @@ using Scalemon.SqlDataAccess;
 using Scalemon.WebApp;              // ISettingsSource, JsonFileSettingsSource, ApiClient (если у тебя в этом неймспейсе)
 using Scalemon.WebApp.Components;
 using Scalemon.WebApp.Data;
+using Scalemon.ServiceHost.Http;
 using Scalemon.ServiceHost.Logging;
 using Serilog;
 using Serilog.Core;
@@ -184,6 +185,7 @@ builder.Services.AddRadzenCookieThemeService(options =>
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddHttpClient();                        // если ApiClient использует HttpClient
 builder.Services.AddScoped<ApiClient>();                 // если он есть и используется из компонентов
+builder.Services.AddTransient<ForwardAuthCookiesHandler>();
 builder.Services.AddHttpClient<ApiClient>((sp, http) =>
 {
     // same-origin базовый адрес
@@ -208,7 +210,7 @@ builder.Services.AddHttpClient<ApiClient>((sp, http) =>
     var raw = $"{cfg.Username}:{cfg.Password}";
     http.DefaultRequestHeaders.Authorization =
         new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(raw)));
-});
+}).AddHttpMessageHandler<ForwardAuthCookiesHandler>();
 
 // Источник настроек UI (если используешь JsonFileSettingsSource)
 builder.Services.AddScoped<ISettingsSource, JsonFileSettingsSource>();


### PR DESCRIPTION
## Summary
- add a delegating handler that forwards the Cookie header from the current request to outgoing ApiClient requests
- register the handler in DI and attach it to the typed ApiClient HttpClient

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e476a7b600832fb14bbbcee63b9a63