### PR TITLE
Fix forwarding of auth cookies

### DIFF
--- a/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
+++ b/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
@@ -29,7 +29,7 @@ public class ForwardAuthCookiesHandler : DelegatingHandler
             {
                 if (CookieHeaderValue.TryParse(value, out var cookie))
                 {
-                    request.Headers.Cookie.Add(cookie);
+                    request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, cookie.ToString());
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- replace the usage of the non-existent Cookie header collection with TryAddWithoutValidation
- ensure parsed cookie header values are added back as strings when forwarding the request

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e47b8bc550832fab616ae225583c49