### PR TITLE
Simplify auth cookie forwarding

### DIFF
--- a/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
+++ b/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,13 +24,9 @@ public class ForwardAuthCookiesHandler : DelegatingHandler
         {
             request.Headers.Remove(HeaderNames.Cookie);
 
-            foreach (var value in cookieHeader)
+            foreach (var value in cookieHeader.ToArray())
             {
-                if (CookieHeaderValue.TryParse(value, out var cookie))
-                {
-                    request.Headers.Cookie.Add(cookie);
-                }
-                else
+                if (!string.IsNullOrEmpty(value))
                 {
                     request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, value);
                 }


### PR DESCRIPTION
## Summary
- remove cookie header parsing and forward only non-empty raw cookie values
- avoid using cookie header types that caused compilation errors
- enumerate cookie header values explicitly before forwarding to satisfy HttpHeaders API expectations

## Testing
- not run (dotnet SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e47b8bc550832fab616ae225583c49