### PR TITLE
Fix cookie forwarding handler

### DIFF
--- a/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
+++ b/Scalemon.ServiceHost/Http/ForwardAuthCookiesHandler.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,23 +18,22 @@ public class ForwardAuthCookiesHandler : DelegatingHandler
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var cookieHeader = _httpContextAccessor.HttpContext?.Request?.Headers[HeaderNames.Cookie];
+        var httpContext = _httpContextAccessor.HttpContext;
 
-        if (!StringValues.IsNullOrEmpty(cookieHeader))
+        if (httpContext?.Request is not { Cookies.Count: > 0 } requestContext)
+        {
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        var cookiePairs = requestContext.Cookies
+            .Select(cookie => $"{cookie.Key}={cookie.Value}")
+            .Where(pair => !string.IsNullOrWhiteSpace(pair))
+            .ToArray();
+
+        if (cookiePairs.Length > 0)
         {
             request.Headers.Remove(HeaderNames.Cookie);
-
-            foreach (var value in cookieHeader.ToArray())
-            {
-                if (CookieHeaderValue.TryParse(value, out var cookie))
-                {
-                    request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, cookie.ToString());
-                }
-                else
-                {
-                    request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, value);
-                }
-            }
+            request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, string.Join("; ", cookiePairs));
         }
 
         return base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
## Summary
- rebuild the forwarding handler to read cookies from the current HTTP context
- reassemble cookies into a single header value before forwarding to avoid invalid formats

## Testing
- dotnet build Scalemon.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e4820f23b4832f9bc4464296dd2365