### PR TITLE
Fix Radzen template form event handlers

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
@@ -97,9 +97,10 @@
         return Task.CompletedTask;
     }
 
-    private void OnInvalidSubmit(FormInvalidSubmitEventArgs args)
+    private Task OnInvalidSubmit(FormInvalidSubmitEventArgs args)
     {
         NotificationService.Notify(NotificationSeverity.Warning, "Пользователи", "Исправьте ошибки формы");
+        return Task.CompletedTask;
     }
 
     private void Cancel()

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -83,7 +83,7 @@
         }
     }
 
-    private async Task HandleLogin()
+    private async Task HandleLogin(LoginModel _)
     {
         if (_busy)
         {

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -509,8 +509,11 @@
         }
     }
 
-    void OnInvalidSubmit(FormInvalidSubmitEventArgs args)
-        => NotificationService.Notify(NotificationSeverity.Warning, "Проверьте поля", "Есть ошибки валидации.");
+    Task OnInvalidSubmit(FormInvalidSubmitEventArgs args)
+    {
+        NotificationService.Notify(NotificationSeverity.Warning, "Проверьте поля", "Есть ошибки валидации.");
+        return Task.CompletedTask;
+    }
 
     private async Task SaveSettingsAsync()
     {


### PR DESCRIPTION
## Summary
- align Radzen TemplateForm submit handlers with the signatures expected by the controls
- ensure invalid submit handlers return tasks so the callbacks can be wired up

## Testing
- not run (environment does not have the .NET SDK)

------
https://chatgpt.com/codex/tasks/task_e_68e4a07f2740832f9034d848ccab081e