### PR TITLE
Disambiguate Radzen form contexts under AuthorizeView

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
@@ -97,9 +97,10 @@
         return Task.CompletedTask;
     }
 
-    private void OnInvalidSubmit(FormInvalidSubmitEventArgs args)
+    private Task OnInvalidSubmit(FormInvalidSubmitEventArgs args)
     {
         NotificationService.Notify(NotificationSeverity.Warning, "Пользователи", "Исправьте ошибки формы");
+        return Task.CompletedTask;
     }
 
     private void Cancel()

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -7,7 +7,7 @@
 @inject AuthenticationStateProvider AuthProvider
 
 <AuthorizeView>
-    <Authorized>
+    <Authorized Context="authState">
         <div class="main-page__authorized">
             <RadzenCard Class="main-page__authorized-card">
                 <RadzenStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="0.75rem">
@@ -19,7 +19,7 @@
             </RadzenCard>
         </div>
     </Authorized>
-    <NotAuthorized>
+    <NotAuthorized Context="authState">
         <div class="main-page__hero">
             <div class="main-page__hero-overlay"></div>
             <RadzenCard Class="main-page__card">
@@ -83,7 +83,7 @@
         }
     }
 
-    private async Task HandleLogin()
+    private async Task HandleLogin(LoginModel _)
     {
         if (_busy)
         {

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -26,7 +26,7 @@
     <!-- 1) ВЕБ-ИНТЕРФЕЙС -->
     <RadzenTabsItem Text="Веб-интерфейс">
         <AuthorizeView Policy="CanViewMonitoring">
-            <Authorized>
+            <Authorized Context="authState">
             <RadzenTemplateForm TItem="SettingsDto"
                                 Data="@Model"
                                 Submit="@OnValidSubmit"
@@ -509,8 +509,11 @@
         }
     }
 
-    void OnInvalidSubmit(FormInvalidSubmitEventArgs args)
-        => NotificationService.Notify(NotificationSeverity.Warning, "Проверьте поля", "Есть ошибки валидации.");
+    Task OnInvalidSubmit(FormInvalidSubmitEventArgs args)
+    {
+        NotificationService.Notify(NotificationSeverity.Warning, "Проверьте поля", "Есть ошибки валидации.");
+        return Task.CompletedTask;
+    }
 
     private async Task SaveSettingsAsync()
     {


### PR DESCRIPTION
## Summary
- set explicit context names on AuthorizeView content that hosts RadzenTemplateForm instances to avoid context collisions

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4a07f2740832f9034d848ccab081e