### PR TITLE
Relax settings page authorization

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -10,7 +10,7 @@
 @using System.IO.Ports
 
 
-@attribute [Authorize(Policy = "CanViewSettings")]
+@attribute [Authorize]
 @implements IDisposable
 
 @inject ApiClient Api
@@ -25,8 +25,6 @@
 
     <!-- 1) ВЕБ-ИНТЕРФЕЙС -->
     <RadzenTabsItem Text="Веб-интерфейс">
-        <AuthorizeView Policy="CanViewMonitoring">
-            <Authorized Context="authState">
             <RadzenTemplateForm TItem="SettingsDto"
                                 Data="@Model"
                                 Submit="@OnValidSubmit"
@@ -130,8 +128,6 @@
                     <RadzenButton Text="Отмена" Icon="cancel" Click="@ReloadAllAsync" />
         </RadzenStack>
       </RadzenTemplateForm>
-            </Authorized>
-        </AuthorizeView>
     </RadzenTabsItem>
 
     <!-- 2) СЛУЖБА -->


### PR DESCRIPTION
## Summary
- allow any authenticated user to access the settings page
- remove the monitoring-specific authorization wrapper from the web interface tab while leaving admin-only guards in place for other tabs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4b7529a78832fbd229228421b1b1f