### PR TITLE
Fix settings page authorization for authenticated users

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -9,9 +9,10 @@
 @using Scalemon.WebApp.Components.Dialogs
 @using System.Linq
 @using System.IO.Ports
+@using System.Security.Claims
 
 
-@attribute [Authorize(Policy = "CanViewMonitoring")]
+@attribute [Authorize]
 @implements IDisposable
 
 @inject ApiClient Api
@@ -450,9 +451,14 @@
     {
         var state = await AuthProvider.GetAuthenticationStateAsync();
         var user = state.User;
-        _isAdmin = user.IsInRole("Admin");
-        _canEdit = _isAdmin || user.IsInRole("Editor");
+        _isAdmin = IsInRole(user, "Admin");
+        _canEdit = _isAdmin || IsInRole(user, "Editor");
     }
+
+    private static bool IsInRole(ClaimsPrincipal user, string role)
+        => user?.FindAll(ClaimTypes.Role)
+                 .Any(c => string.Equals(c.Value, role, StringComparison.OrdinalIgnoreCase))
+           ?? false;
 
     private async Task ReloadAllAsync()
     {


### PR DESCRIPTION
## Summary
- allow the settings page to be accessed by any authenticated user instead of requiring the monitoring policy
- make role detection on the settings page case-insensitive so administrators keep all tabs and other roles stay restricted

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4d4d755f0832faecbf4dc6dfbbb8c