### PR TITLE
Refactor UI security to use Radzen-style service

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -21,6 +21,7 @@ using Scalemon.SignalBus;
 using Scalemon.SqlDataAccess;
 using Scalemon.WebApp;              // ISettingsSource, JsonFileSettingsSource, ApiClient (если у тебя в этом неймспейсе)
 using Scalemon.WebApp.Components;
+using Scalemon.WebApp.Security;
 using Scalemon.WebApp.Data;
 using Scalemon.ServiceHost.Http;
 using Scalemon.ServiceHost.Logging;
@@ -184,6 +185,7 @@ builder.Services.AddRadzenCookieThemeService(options =>
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddHttpClient();                        // если ApiClient использует HttpClient
 builder.Services.AddScoped<ApiClient>();                 // если он есть и используется из компонентов
+builder.Services.AddScoped<SecurityService>();
 builder.Services.AddTransient<ForwardAuthCookiesHandler>();
 builder.Services.AddHttpClient<ApiClient>((sp, http) =>
 {

--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -1,9 +1,9 @@
 @using Microsoft.AspNetCore.Components.Routing
-@using Microsoft.AspNetCore.Components.Authorization
 @inherits LayoutComponentBase
 
 @inject NavigationManager Nav
 @inject IJSRuntime JS
+@inject SecurityService Security
 @implements IAsyncDisposable
 
 <RadzenLayout>
@@ -23,55 +23,59 @@
                 <RadzenText Text="·" Class="rz-ml-1 rz-mr-1" />
                 <RadzenText Text="@_pageTitle" TextStyle="TextStyle.H6" Class="rz-text-secondary" />
             </RadzenStack>
-            <AuthorizeView>
-                <Authorized>
-                    <RadzenStack Orientation="Orientation.Horizontal"
-                                 AlignItems="AlignItems.Center"
-                                 Gap="8">
-                        <RadzenIcon Icon="account_circle" />
-                        <RadzenText Class="rz-text-secondary">@context.User.Identity?.Name</RadzenText>
-                        <RadzenButton Icon="logout"
-                                      ButtonStyle="ButtonStyle.Secondary"
-                                      Size="ButtonSize.Small"
-                                      Click="Logout"
-                                      Text="Выход" />
-                    </RadzenStack>
-                </Authorized>
-            </AuthorizeView>
+            @if (_isAuthenticated)
+            {
+                <RadzenStack Orientation="Orientation.Horizontal"
+                             AlignItems="AlignItems.Center"
+                             Gap="8">
+                    <RadzenIcon Icon="account_circle" />
+                    <RadzenText Class="rz-text-secondary">@_userName</RadzenText>
+                    <RadzenButton Icon="logout"
+                                  ButtonStyle="ButtonStyle.Secondary"
+                                  Size="ButtonSize.Small"
+                                  Click="Logout"
+                                  Text="Выход" />
+                </RadzenStack>
+            }
         </RadzenStack>
     </RadzenHeader>
 
-    <AuthorizeView>
-        <Authorized>
-            <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
-                <NavMenu Collapsed="@(navCollapsed)"
-                         OnToggleSidebar="ToggleSidebar" />
-            </RadzenSidebar>
-        </Authorized>
-    </AuthorizeView>
+    @if (_isAuthenticated)
+    {
+        <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
+            <NavMenu Collapsed="@(navCollapsed)"
+                     OnToggleSidebar="ToggleSidebar" />
+        </RadzenSidebar>
+    }
 
     <RadzenBody>
         <div class="rz-p-3">
             @Body
         </div>
 
-        <AuthorizeView>
-            <Authorized>
-                <!-- Cлужебные компоненты Radzen -->
-                <RadzenDialog />
-                <RadzenNotification />
-                <RadzenContextMenu />
-            </Authorized>
-        </AuthorizeView>
+        @if (_isAuthenticated)
+        {
+            <!-- Cлужебные компоненты Radzen -->
+            <RadzenDialog />
+            <RadzenNotification />
+            <RadzenContextMenu />
+        }
     </RadzenBody>
 </RadzenLayout>
 
 @code {
     private string _pageTitle = "Главная";
     private bool navCollapsed;
+    private bool _isAuthenticated;
+    private string? _userName;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        await base.OnInitializedAsync();
+        await Security.InitializeAsync();
+        Security.SecurityStateChanged += OnSecurityStateChanged;
+
+        UpdateSecurityState();
         SetPageTitle(Nav.Uri);
         Nav.LocationChanged += OnLocationChanged;
     }
@@ -90,7 +94,8 @@
             "/logs" => "Логи службы Scalemon",
             "/statistics" => "Статистика",
             "/settings" => "Настройки",
-            "/" or "/about" => "О программе",
+            "/" => "Главная",
+            "/about" => "О программе",
             _ => "Страница"
         };
         StateHasChanged();
@@ -111,6 +116,19 @@
     public ValueTask DisposeAsync()
     {
         Nav.LocationChanged -= OnLocationChanged;
+        Security.SecurityStateChanged -= OnSecurityStateChanged;
         return ValueTask.CompletedTask;
+    }
+
+    private void OnSecurityStateChanged()
+    {
+        UpdateSecurityState();
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void UpdateSecurityState()
+    {
+        _isAuthenticated = Security.IsAuthenticated();
+        _userName = Security.UserName;
     }
 }

--- a/Scalemon.WebApp/Components/Layout/NavMenu.razor
+++ b/Scalemon.WebApp/Components/Layout/NavMenu.razor
@@ -1,6 +1,5 @@
-@using Microsoft.AspNetCore.Components.Authorization
-
-
+@inject SecurityService Security
+@implements IDisposable
 
 <!-- Вся колонка панели -->
 <div style="height:100%;display:flex;flex-direction:column">
@@ -36,33 +35,39 @@
     [Parameter] public bool Collapsed { get; set; }
     [Parameter] public EventCallback OnToggleSidebar { get; set; }
 
-    [CascadingParameter] private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
-
     private bool _isAuthenticated;
-    private bool _isEditor;
-    private bool _isAdmin;
+    private bool _canSeeLogs;
 
     private string ToggleIcon => Collapsed ? "keyboard_double_arrow_right" : "keyboard_double_arrow_left";
     private string ToggleText => Collapsed ? "Развернуть" : "Свернуть";
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnInitializedAsync()
     {
-        if (AuthenticationStateTask is null)
-        {
-            _isAuthenticated = false;
-            _isEditor = _isAdmin = false;
-            return;
-        }
-
-        var state = await AuthenticationStateTask;
-        var user = state.User;
-        _isAuthenticated = user.Identity?.IsAuthenticated ?? false;
-        _isAdmin = user.IsInRole("Admin");
-        _isEditor = user.IsInRole("Editor");
+        await base.OnInitializedAsync();
+        await Security.InitializeAsync();
+        Security.SecurityStateChanged += OnSecurityChanged;
+        UpdateSecurityState();
     }
 
     private Task ToggleMenuItemClick(MenuItemEventArgs _)
         => OnToggleSidebar.InvokeAsync();
 
-    private bool CanSeeLogs => _isAdmin || _isEditor;
+    private void UpdateSecurityState()
+    {
+        _isAuthenticated = Security.IsAuthenticated();
+        _canSeeLogs = Security.IsInAnyRole("Admin", "Editor");
+    }
+
+    private void OnSecurityChanged()
+    {
+        UpdateSecurityState();
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private bool CanSeeLogs => _canSeeLogs;
+
+    public void Dispose()
+    {
+        Security.SecurityStateChanged -= OnSecurityChanged;
+    }
 }

--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -12,8 +12,9 @@
 @inject NavigationManager Nav
 @inject ApiClient Api
 @inject IJSRuntime JS
-@inject NotificationService NotificationService 
-@inject ProtectedLocalStorage PLS 
+@inject NotificationService NotificationService
+@inject ProtectedLocalStorage PLS
+@inject SecurityService Security
 
 @attribute [StreamRendering]
 @attribute [Authorize(Policy = "CanEdit")]
@@ -48,14 +49,10 @@
     </RadzenStack>
   </RadzenStack>
 
-  <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem">
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem">
     <RadzenButton Icon="refresh" Text="Обновить" Click="@ReloadAsync" ButtonStyle="ButtonStyle.Primary" />
     <RadzenButton Icon="download" Text="Экспорт CSV" Click="@DownloadCsv" />
-    <AuthorizeView Roles="Admin">
-        <Authorized>
-            <RadzenButton Icon="upload" Text="Импорт логов" Click="@TriggerImportDialogAsync" />
-        </Authorized>
-    </AuthorizeView>
+    <RadzenButton Icon="upload" Text="Импорт логов" Click="@TriggerImportDialogAsync" Visible="@Security.IsInRole(\"Admin\")" />
   </RadzenStack>
 </RadzenStack>
 
@@ -181,6 +178,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await base.OnInitializedAsync();
+        await Security.InitializeAsync();
         await LoadUiStateAsync();
         SetupTimer();
     }

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -1,72 +1,81 @@
 @page "/"
-@using Microsoft.AspNetCore.Components.Authorization
 @using System.ComponentModel.DataAnnotations
 
 @inject IJSRuntime JS
 @inject NavigationManager Nav
-@inject AuthenticationStateProvider AuthProvider
+@inject SecurityService Security
+@implements IDisposable
 
-<AuthorizeView>
-    <Authorized Context="authState">
-        <div class="main-page__authorized">
-            <RadzenCard Class="main-page__authorized-card">
-                <RadzenStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="0.75rem">
-                    <RadzenIcon Icon="check_circle" Style="font-size:48px;color:var(--rz-success)" />
+@if (_isAuthenticated)
+{
+    <div class="main-page__authorized">
+        <RadzenCard Class="main-page__authorized-card">
+            <RadzenStack Orientation="Orientation.Vertical" AlignItems="AlignItems.Center" Gap="0.75rem">
+                <RadzenIcon Icon="check_circle" Style="font-size:48px;color:var(--rz-success)" />
+                <RadzenText TextStyle="TextStyle.H5" TextAlign="TextAlign.Center">
+                    Вы уже авторизованы. Перенаправляем на рабочую область…
+                </RadzenText>
+            </RadzenStack>
+        </RadzenCard>
+    </div>
+}
+else
+{
+    <div class="main-page__hero">
+        <div class="main-page__hero-overlay"></div>
+        <RadzenCard Class="main-page__card rz-w-25">
+            <RadzenStack Orientation="Orientation.Vertical" Gap="1.5rem">
+                <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                    <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width:140px" AlternateText="ScaleMonitoring" />
                     <RadzenText TextStyle="TextStyle.H5" TextAlign="TextAlign.Center">
-                        Вы уже авторизованы. Перенаправляем на рабочую область…
+                        Добро пожаловать! Войдите, чтобы продолжить.
                     </RadzenText>
                 </RadzenStack>
-            </RadzenCard>
-        </div>
-    </Authorized>
-    <NotAuthorized Context="authState">
-        <div class="main-page__hero">
-            <div class="main-page__hero-overlay"></div>
-            <RadzenCard Class="main-page__card rz-w-25">
-                <RadzenStack Orientation="Orientation.Vertical" Gap="1.5rem">
-                    <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
-                        <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width:140px" AlternateText="ScaleMonitoring" />
-                        <RadzenText TextStyle="TextStyle.H5" TextAlign="TextAlign.Center">
-                            Добро пожаловать! Войдите, чтобы продолжить.
-                        </RadzenText>
+
+                <RadzenTemplateForm TItem="LoginModel" Data="@model" Submit="@HandleLogin" class="main-page__form">
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
+                        <RadzenFormField Text="Логин">
+                            <RadzenTextBox @bind-Value="model.Username" Name="Username" Style="width:100%" Disabled="@_busy" />
+                            <RadzenRequiredValidator Component="Username" Text="Введите логин" Popup="false" />
+                        </RadzenFormField>
+
+                        <RadzenFormField Text="Пароль">
+                            <RadzenPassword @bind-Value="model.Password" Name="Password" Style="width:100%" Disabled="@_busy" />
+                            <RadzenRequiredValidator Component="Password" Text="Введите пароль" Popup="false" />
+                        </RadzenFormField>
+
+                        @if (!string.IsNullOrWhiteSpace(_error))
+                        {
+                            <div class="main-page__error">@_error</div>
+                        }
+
+                        <RadzenButton Icon="login"
+                                      Text="Войти"
+                                      ButtonStyle="ButtonStyle.Primary"
+                                      ButtonType="ButtonType.Submit"
+                                      Disabled="@_busy"
+                                      Style="width:100%" />
                     </RadzenStack>
-
-                    <RadzenTemplateForm TItem="LoginModel" Data="@model" Submit="@HandleLogin" class="main-page__form">
-                        <RadzenStack Orientation="Orientation.Vertical" Gap="1rem">
-                            <RadzenFormField Text="Логин">
-                                <RadzenTextBox @bind-Value="model.Username" Name="Username" Style="width:100%" Disabled="@_busy" />
-                                <RadzenRequiredValidator Component="Username" Text="Введите логин" Popup="false" />
-                            </RadzenFormField>
-
-                            <RadzenFormField Text="Пароль">
-                                <RadzenPassword @bind-Value="model.Password" Name="Password" Style="width:100%" Disabled="@_busy" />
-                                <RadzenRequiredValidator Component="Password" Text="Введите пароль" Popup="false" />
-                            </RadzenFormField>
-
-                            @if (!string.IsNullOrWhiteSpace(_error))
-                            {
-                                <div class="main-page__error">@_error</div>
-                            }
-
-                            <RadzenButton Icon="login"
-                                          Text="Войти"
-                                          ButtonStyle="ButtonStyle.Primary"
-                                          ButtonType="ButtonType.Submit"
-                                          Disabled="@_busy"
-                                          Style="width:100%" />
-                        </RadzenStack>
-                    </RadzenTemplateForm>
-                </RadzenStack>
-            </RadzenCard>
-        </div>
-    </NotAuthorized>
-</AuthorizeView>
+                </RadzenTemplateForm>
+            </RadzenStack>
+        </RadzenCard>
+    </div>
+}
 
 @code {
     private readonly LoginModel model = new();
     private bool _busy;
     private string? _error;
     private bool _redirected;
+    private bool _isAuthenticated;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        await Security.InitializeAsync();
+        Security.SecurityStateChanged += OnSecurityStateChanged;
+        UpdateAuthenticationState();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -75,8 +84,8 @@
             return;
         }
 
-        var state = await AuthProvider.GetAuthenticationStateAsync();
-        if (state.User.Identity?.IsAuthenticated == true)
+        await Security.InitializeAsync();
+        if (Security.IsAuthenticated())
         {
             _redirected = true;
             Nav.NavigateTo("/monitoring", replace: true);
@@ -119,6 +128,22 @@
             _busy = false;
             StateHasChanged();
         }
+    }
+
+    private void OnSecurityStateChanged()
+    {
+        UpdateAuthenticationState();
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void UpdateAuthenticationState()
+    {
+        _isAuthenticated = Security.IsAuthenticated();
+    }
+
+    public void Dispose()
+    {
+        Security.SecurityStateChanged -= OnSecurityStateChanged;
     }
 
     sealed class LoginModel

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -1,7 +1,6 @@
 ﻿@page "/monitoring"
 @using System.Globalization
 @using Microsoft.AspNetCore.Authorization
-@using Microsoft.AspNetCore.Components.Authorization
 @using Scalemon.WebApp.Models
 @using Scalemon.WebApp.Data
 @using static Scalemon.WebApp.Models.WeighingModels
@@ -11,7 +10,7 @@
 @attribute [Authorize(Policy = "CanViewMonitoring")]
 @inject IWeighingDataService Data
 @inject NavigationManager Nav
-@inject AuthenticationStateProvider AuthProvider
+@inject SecurityService Security
 
 <RadzenRow>   
 
@@ -156,9 +155,8 @@
 
     async Task DeterminePermissionsAsync()
     {
-        var state = await AuthProvider.GetAuthenticationStateAsync();
-        var user = state.User;
-        _canEdit = user.IsInRole("Editor") || user.IsInRole("Admin");
+        await Security.InitializeAsync();
+        _canEdit = Security.IsInAnyRole("Editor", "Admin");
     }
 
     async Task OnMonthChanged((int Year, int Month) arg)

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -3,16 +3,14 @@
 @using System.Collections.Generic
 @using System.Threading
 @using Microsoft.AspNetCore.Authorization
-@using Microsoft.AspNetCore.Components.Authorization
 @using Scalemon.Common
 @using Scalemon.WebApp.Models
 @using Scalemon.WebApp.Components.Dialogs
 @using System.Linq
 @using System.IO.Ports
-@using System.Security.Claims
 
 
-@attribute [Authorize]
+@attribute [Authorize(Policy = "CanViewSettings")]
 @implements IDisposable
 
 @inject ApiClient Api
@@ -21,7 +19,7 @@
 @inject ISettingsSource SettingsSource
 @inject IWebHostEnvironment Env
 @inject ThemeService ThemeService
-@inject AuthenticationStateProvider AuthProvider
+@inject SecurityService Security
 
 <RadzenTabs RenderMode="TabRenderMode.Server">
 
@@ -436,7 +434,9 @@
     // ---------- Инициализация ----------
     protected override async Task OnInitializedAsync()
     {
-        await ResolvePermissionsAsync();
+        await base.OnInitializedAsync();
+        await Security.InitializeAsync();
+        ResolvePermissions();
 
         _cts = new CancellationTokenSource();
 
@@ -447,18 +447,11 @@
         await ReloadAllAsync();
     }
 
-    private async Task ResolvePermissionsAsync()
+    private void ResolvePermissions()
     {
-        var state = await AuthProvider.GetAuthenticationStateAsync();
-        var user = state.User;
-        _isAdmin = IsInRole(user, "Admin");
-        _canEdit = _isAdmin || IsInRole(user, "Editor");
+        _isAdmin = Security.IsInRole("Admin");
+        _canEdit = _isAdmin || Security.IsInRole("Editor");
     }
-
-    private static bool IsInRole(ClaimsPrincipal user, string role)
-        => user?.FindAll(ClaimTypes.Role)
-                 .Any(c => string.Equals(c.Value, role, StringComparison.OrdinalIgnoreCase))
-           ?? false;
 
     private async Task ReloadAllAsync()
     {

--- a/Scalemon.WebApp/Components/RecordDetailsPanel.razor
+++ b/Scalemon.WebApp/Components/RecordDetailsPanel.razor
@@ -18,14 +18,17 @@
 				</RadzenStack>
             </RadzenStack>
             <!-- Горизонтальный ряд кнопок действий -->
-            <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
-                <RadzenButton Icon="add" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("inc"))" Disabled="@(!CanEdit)" />
-                <RadzenButton Icon="remove" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("dec"))" Disabled="@(!CanEdit)" />
-                <RadzenButton Icon="vertical_align_top" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("addAbove"))" Disabled="@(!CanEdit)" />
-                <RadzenButton Icon="vertical_align_bottom" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("addBelow"))" Disabled="@(!CanEdit)" />
-                <RadzenButton Icon="delete" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("delete"))" Disabled="@(!CanEdit)" />
-                <RadzenButton Icon="description" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("logs"))" Disabled="@(!CanEdit)" />
-            </RadzenStack>
+            @if (CanEdit)
+            {
+                <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
+                    <RadzenButton Icon="add" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("inc"))" />
+                    <RadzenButton Icon="remove" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("dec"))" />
+                    <RadzenButton Icon="vertical_align_top" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("addAbove"))" />
+                    <RadzenButton Icon="vertical_align_bottom" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("addBelow"))" />
+                    <RadzenButton Icon="delete" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("delete"))" />
+                    <RadzenButton Icon="description" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => DoAction("logs"))" />
+                </RadzenStack>
+            }
         </RadzenStack>
     </RadzenCard>
   

--- a/Scalemon.WebApp/Components/_Imports.razor
+++ b/Scalemon.WebApp/Components/_Imports.razor
@@ -11,6 +11,7 @@
 @using Scalemon.WebApp.Components
 @using Scalemon.WebApp.Data
 @using Scalemon.WebApp.Models
+@using Scalemon.WebApp.Security
 @using static Scalemon.WebApp.Models.WeighingModels
 @using Radzen
 @using Radzen.Blazor

--- a/Scalemon.WebApp/Security/SecurityService.cs
+++ b/Scalemon.WebApp/Security/SecurityService.cs
@@ -1,0 +1,132 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Scalemon.WebApp.Security;
+
+/// <summary>
+///     Simplified security service that mirrors the Radzen security API surface
+///     for working with roles inside Blazor components.
+/// </summary>
+public sealed class SecurityService : IDisposable
+{
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private ClaimsPrincipal _user = new(new ClaimsIdentity());
+    private Task? _initializationTask;
+    private bool _disposed;
+
+    public SecurityService(AuthenticationStateProvider authenticationStateProvider)
+    {
+        _authenticationStateProvider = authenticationStateProvider;
+    }
+
+    public event Action? SecurityStateChanged;
+
+    public async Task InitializeAsync()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(SecurityService));
+        }
+
+        if (_initializationTask is null)
+        {
+            _initializationTask = InitializeCoreAsync();
+        }
+
+        await _initializationTask.ConfigureAwait(false);
+    }
+
+    public bool IsAuthenticated() => _user.Identity?.IsAuthenticated == true;
+
+    public string? UserName => _user.Identity?.Name;
+
+    public bool IsInRole(string role)
+        => !string.IsNullOrWhiteSpace(role) && _user.IsInRole(role);
+
+    public bool IsInAnyRole(params string[] roles)
+    {
+        if (roles is null || roles.Length == 0)
+        {
+            return false;
+        }
+
+        return roles.Any(IsInRole);
+    }
+
+    public Task<bool> IsInRoleAsync(string role)
+        => Task.FromResult(IsInRole(role));
+
+    public Task<bool> IsInAnyRoleAsync(params string[] roles)
+        => Task.FromResult(IsInAnyRole(roles));
+
+    public async Task<ClaimsPrincipal> GetUserAsync()
+    {
+        await InitializeAsync().ConfigureAwait(false);
+        return _user;
+    }
+
+    public async Task RefreshAsync()
+    {
+        await InitializeAsync().ConfigureAwait(false);
+        await UpdateCurrentUserAsync().ConfigureAwait(false);
+    }
+
+    private async Task InitializeCoreAsync()
+    {
+        _authenticationStateProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
+        await UpdateCurrentUserAsync().ConfigureAwait(false);
+    }
+
+    private async Task UpdateCurrentUserAsync()
+    {
+        var state = await _authenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(false);
+        SetUser(state.User);
+    }
+
+    private void OnAuthenticationStateChanged(Task<AuthenticationState> task)
+    {
+        _ = UpdateFromAuthenticationStateAsync(task);
+    }
+
+    private async Task UpdateFromAuthenticationStateAsync(Task<AuthenticationState> task)
+    {
+        try
+        {
+            var state = await task.ConfigureAwait(false);
+            SetUser(state.User);
+        }
+        catch
+        {
+            // ignored – if the task faults we keep the previous user
+        }
+    }
+
+    private void SetUser(ClaimsPrincipal? user)
+    {
+        var previousAuthenticated = IsAuthenticated();
+        _user = user ?? new ClaimsPrincipal(new ClaimsIdentity());
+
+        if (previousAuthenticated != IsAuthenticated())
+        {
+            SecurityStateChanged?.Invoke();
+            return;
+        }
+
+        SecurityStateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_initializationTask is not null)
+        {
+            _authenticationStateProvider.AuthenticationStateChanged -= OnAuthenticationStateChanged;
+        }
+
+        _disposed = true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Radzen-style `SecurityService` wrapper so components can use Radzen security helpers for role checks
- update layouts, navigation, and major pages to rely on the security service for redirect rules and role-based visibility
- hide monitoring detail actions for viewers and limit the logs import action to administrators only

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4df937618832f96372a8c0433887a