### PR TITLE
Improve login redirect handling and align authorization roles

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -152,23 +152,22 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.Cookie.Name = "ScalemonAuth";
         options.SlidingExpiration = true;
         options.ExpireTimeSpan = TimeSpan.FromDays(365);
+        options.LoginPath = "/login";
+        options.AccessDeniedPath = "/login";
         options.Events.OnRedirectToLogin = context =>
         {
             if (context.Request.Path.StartsWithSegments("/api"))
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
             else
-                context.Response.Redirect(context.RedirectUri);
+            {
+                var returnUrl = context.Request.Path + context.Request.QueryString;
+                var redirectUri = options.LoginPath + "?returnUrl=" + Uri.EscapeDataString(returnUrl);
+                context.Response.Redirect(redirectUri);
+            }
             return Task.CompletedTask;
         };
     });
-builder.Services.AddAuthorization(options =>
-{
-    // Политики доступа к страницам/функциям
-    options.AddPolicy("CanViewMonitoring", p => p.RequireRole("Viewer", "Editor", "Admin"));
-    options.AddPolicy("CanEdit", p => p.RequireRole("Editor", "Admin"));
-    options.AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
-    // Добавьте другие политики, если они вам нужны
-});
+builder.Services.AddAuthorization();
 
 // Сервисы для Blazor и Radzen UI
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();

--- a/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
+++ b/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
@@ -1,0 +1,29 @@
+@using System
+@inject NavigationManager Nav
+
+@if (_redirectStarted)
+{
+    <p>Перенаправление на страницу входа...</p>
+}
+else
+{
+    <p>Готовим перенаправление на страницу входа...</p>
+}
+
+@code {
+    private bool _redirectStarted;
+
+    protected override void OnInitialized()
+    {
+        if (_redirectStarted)
+        {
+            return;
+        }
+
+        _redirectStarted = true;
+        var uri = new Uri(Nav.Uri);
+        var returnUrl = uri.PathAndQuery + uri.Fragment;
+        var loginUrl = "/login?returnUrl=" + Uri.EscapeDataString(returnUrl);
+        Nav.NavigateTo(loginUrl, forceLoad: true);
+    }
+}

--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -112,15 +112,12 @@
     // Простейшие заглушки под ваши реальные процедуры авторизации
     private Task Login()
     {
-        var target = new Uri(Nav.Uri).PathAndQuery;
-        var loginUrl = $"/login?returnUrl={Uri.EscapeDataString(target)}";
-        Nav.NavigateTo(loginUrl);
+        Nav.NavigateTo("/login");
         return Task.CompletedTask;
     }
 
     private async Task Logout()
     {
-        // Ваш существующий сценарий выхода
         await JS.InvokeVoidAsync("scalemon.logout");
         Nav.NavigateTo("/login", forceLoad: true);
     }

--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -15,7 +15,7 @@
 @inject ProtectedLocalStorage PLS 
 
 @attribute [StreamRendering]
-@attribute [Authorize(Policy = "CanEdit")]
+@attribute [Authorize(Roles = "Editor,Admin")]
 
 <PageTitle>Логи службы Scalemon</PageTitle>
 

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -7,7 +7,7 @@
 @using Microsoft.AspNetCore.WebUtilities
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @inject ProtectedLocalStorage PLS
-@attribute [Authorize(Policy = "CanEdit")]
+@attribute [Authorize(Roles = "Editor,Admin")]
 @inject IWeighingDataService Data
 @inject NavigationManager Nav
 

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -10,7 +10,7 @@
 @using System.IO.Ports
 
 
-@attribute [Authorize(Policy = "AdminOnly")]
+@attribute [Authorize(Roles = "Admin")]
 @implements IDisposable
 
 @inject ApiClient Api

--- a/Scalemon.WebApp/Components/Routes.razor
+++ b/Scalemon.WebApp/Components/Routes.razor
@@ -2,12 +2,13 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Authorization
 
+@using Scalemon.WebApp.Components.Auth
+
 <Router AppAssembly="typeof(App).Assembly">
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="@routeData" DefaultLayout="typeof(Layout.MainLayout)">
             <NotAuthorized>
-                @* Можно показать заглушку или просто отправить на главную *@
-                <RadzenText TextStyle="TextStyle.DisplayH4" class="rz-mx-auto">Незнакомцам доступа нет!</RadzenText>
+                <RedirectToLogin />
             </NotAuthorized>
         </AuthorizeRouteView>
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />

--- a/Scalemon.WebApp/wwwroot/auth.js
+++ b/Scalemon.WebApp/wwwroot/auth.js
@@ -10,10 +10,11 @@ window.scalemon = {
         return r.ok;
     },
     logout: async function () {
-        await fetch('/api/auth/logout', {
+        const response = await fetch('/api/auth/logout', {
             method: 'POST',
             credentials: 'include'                // <-- важно!
         });
+        return response.ok;
     }
 };
 


### PR DESCRIPTION
## Summary
- configure cookie authentication to redirect unauthenticated requests to the login page while keeping API calls at 401
- add a Blazor component that sends unauthorized users to the login screen and update layouts to rely on Blazor navigation for login/logout
- switch authorization attributes to role strings and simplify client logout helper

## Testing
- ⚠️ `dotnet build Scalemon.sln` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e632da4b88832f952d429c9d83a341