### PR TITLE
Remove AuthorizeView usage and secure public pages

### DIFF
--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -23,34 +23,26 @@
                 <RadzenText Text="·" Class="rz-ml-1 rz-mr-1" />
                 <RadzenText Text="@_pageTitle" TextStyle="TextStyle.H6" Class="rz-text-secondary" />
             </RadzenStack>
-            @if (!_isLoginPage)
+            @if (!_isLoginPage && !_isAuthenticated)
             {
-                <AuthorizeView>
-                    <NotAuthorized>
-                        <RadzenButton Icon="login"
-                                      Text="Войти"
-                                      ButtonStyle="ButtonStyle.Primary"
-                                      Size="ButtonSize.Small"
-                                      Click="Login" />
-                    </NotAuthorized>
-                </AuthorizeView>
+                <RadzenButton Icon="login"
+                              Text="Войти"
+                              ButtonStyle="ButtonStyle.Primary"
+                              Size="ButtonSize.Small"
+                              Click="Login" />
             }
         </RadzenStack>
     </RadzenHeader>
 
-    @if (!_isLoginPage)
+    @if (!_isLoginPage && _isAuthenticated)
     {
-        <AuthorizeView>
-            <Authorized>
-                <!-- ВАЖНО: не привязываем Expanded, держим панель всегда видимой -->
-                <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
-                    <NavMenu Collapsed="@(navCollapsed)"
-                             OnToggleSidebar="ToggleSidebar"
-                             OnLogin="Login"
-                             OnLogout="Logout" />
-                </RadzenSidebar>
-            </Authorized>
-        </AuthorizeView>
+        <!-- ВАЖНО: не привязываем Expanded, держим панель всегда видимой -->
+        <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
+            <NavMenu Collapsed="@(navCollapsed)"
+                     OnToggleSidebar="ToggleSidebar"
+                     OnLogin="Login"
+                     OnLogout="Logout" />
+        </RadzenSidebar>
     }
 
     <RadzenBody>
@@ -72,6 +64,10 @@
     private string _pageTitle = "Главная";
     private bool navCollapsed = false; // false=широкая, true=узкая рейка
     private bool _isLoginPage;
+    private bool _isAuthenticated;
+
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
 
     protected override void OnInitialized()
     {
@@ -101,6 +97,17 @@
             _ => "Страница"
         };
         StateHasChanged();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (AuthenticationStateTask is not null)
+        {
+            var authState = await AuthenticationStateTask;
+            _isAuthenticated = authState.User.Identity?.IsAuthenticated ?? false;
+        }
+
+        await base.OnParametersSetAsync();
     }
 
     private Task ToggleSidebar()

--- a/Scalemon.WebApp/Components/Layout/NavMenu.razor
+++ b/Scalemon.WebApp/Components/Layout/NavMenu.razor
@@ -6,11 +6,29 @@
     [Parameter] public EventCallback OnLogin { get; set; }
     [Parameter] public EventCallback OnLogout { get; set; }
 
+    [CascadingParameter] private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
+
+    private bool _isAuthenticated;
+    private string? _userName;
+
     private string ToggleIcon => Collapsed ? "keyboard_double_arrow_right" : "keyboard_double_arrow_left";
     private string ToggleText => Collapsed ? "Развернуть" : "Свернуть";
 
     private Task ToggleMenuItemClick(MenuItemEventArgs _)
         => OnToggleSidebar.InvokeAsync();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (AuthenticationStateTask is not null)
+        {
+            var authState = await AuthenticationStateTask;
+            var user = authState.User;
+            _isAuthenticated = user.Identity?.IsAuthenticated ?? false;
+            _userName = _isAuthenticated ? user.Identity?.Name : null;
+        }
+
+        await base.OnParametersSetAsync();
+    }
 }
 
 <!-- Вся колонка панели -->
@@ -39,29 +57,29 @@
         </RadzenPanelMenu>
 
         <div class="rz-p-2">
-            <AuthorizeView>
-                <Authorized>
-                    <div style="display:flex;align-items:center;gap:.5rem">
-                        <RadzenIcon Icon="account_circle" />
-                        @if (!Collapsed)
-                        {
-                            <RadzenLabel Text="@context.User.Identity?.Name" />
-                        }
-                        <RadzenButton Icon="logout"
-                                      Text="@(Collapsed ? null : "Выход")"
-                                      ButtonStyle="ButtonStyle.Secondary"
-                                      Size="ButtonSize.Small"
-                                      Click="() => OnLogout.InvokeAsync()" />
-                    </div>
-                </Authorized>
-                <NotAuthorized>
-                    <RadzenButton Icon="login"
-                                  Text="@(Collapsed ? null : "Войти")"
-                                  ButtonStyle="ButtonStyle.Primary"
+            @if (_isAuthenticated)
+            {
+                <div style="display:flex;align-items:center;gap:.5rem">
+                    <RadzenIcon Icon="account_circle" />
+                    @if (!Collapsed && !string.IsNullOrWhiteSpace(_userName))
+                    {
+                        <RadzenLabel Text="@_userName" />
+                    }
+                    <RadzenButton Icon="logout"
+                                  Text="@(Collapsed ? null : "Выход")"
+                                  ButtonStyle="ButtonStyle.Secondary"
                                   Size="ButtonSize.Small"
-                                  Click="() => OnLogin.InvokeAsync()" />
-                </NotAuthorized>
-            </AuthorizeView>
+                                  Click="() => OnLogout.InvokeAsync()" />
+                </div>
+            }
+            else
+            {
+                <RadzenButton Icon="login"
+                              Text="@(Collapsed ? null : "Войти")"
+                              ButtonStyle="ButtonStyle.Primary"
+                              Size="ButtonSize.Small"
+                              Click="() => OnLogin.InvokeAsync()" />
+            }
         </div>
     </div>
 </div>

--- a/Scalemon.WebApp/Components/Pages/About.razor
+++ b/Scalemon.WebApp/Components/Pages/About.razor
@@ -1,17 +1,7 @@
 @page "/about"
-@using Microsoft.AspNetCore.Components.Authorization
+@attribute [Authorize]
 
-<AuthorizeView>
-    <Authorized>
-        <RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
-            <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="Imperium Caeli" />
-            <RadzenText TextStyle="TextStyle.DisplayH3">Здесь будет описание программы и рекламный текст</RadzenText>
-        </RadzenStack>
-    </Authorized>
-    <NotAuthorized>
-        <RadzenStack AlignItems="AlignItems.Center" Gap="16" class="rz-mx-auto rz-my-12">
-            <RadzenText TextStyle="TextStyle.DisplayH4">Нет доступа незнакомцам!</RadzenText>
-            <RadzenLink Path="/login" Text="Перейти к странице входа" Class="rz-font-weight-semibold" />
-        </RadzenStack>
-    </NotAuthorized>
-</AuthorizeView>
+<RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
+    <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="Imperium Caeli" />
+    <RadzenText TextStyle="TextStyle.DisplayH3">Здесь будет описание программы и рекламный текст</RadzenText>
+</RadzenStack>

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -1,17 +1,7 @@
 @page "/"
-@using Microsoft.AspNetCore.Components.Authorization
+@attribute [Authorize]
 
-<AuthorizeView>
-    <Authorized>
-        <RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
-            <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="community" />
-            <RadzenText TextStyle="TextStyle.DisplayH3">Главная страница с логином</RadzenText>
-        </RadzenStack>
-    </Authorized>
-    <NotAuthorized>
-        <RadzenStack AlignItems="AlignItems.Center" Gap="16" class="rz-mx-auto rz-my-12">
-            <RadzenText TextStyle="TextStyle.DisplayH4">Нет доступа незнакомцам!</RadzenText>
-            <RadzenLink Path="/login" Text="Перейти к странице входа" Class="rz-font-weight-semibold" />
-        </RadzenStack>
-    </NotAuthorized>
-</AuthorizeView>
+<RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
+    <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="community" />
+    <RadzenText TextStyle="TextStyle.DisplayH3">Главная страница с логином</RadzenText>
+</RadzenStack>

--- a/Scalemon.WebApp/Components/_Imports.razor
+++ b/Scalemon.WebApp/Components/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
 @using Scalemon.WebApp
 @using Scalemon.WebApp.Components


### PR DESCRIPTION
## Summary
- replace AuthorizeView wrappers in the main layout and navigation menu with authentication state checks
- require authorization on the main and about pages so unauthenticated users are redirected to the login screen
- add a shared import for Microsoft.AspNetCore.Authorization to support the new attributes

## Testing
- dotnet build Scalemon.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e637056fc0832fa61f80290cf254ec