### PR TITLE
Restrict users to selecting a single role

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/UserEditDialog.razor
@@ -18,8 +18,11 @@
                 <RadzenTextBox @bind-Value="Model.DisplayName" Name="DisplayName" Style="width:100%" />
             </RadzenFormField>
 
-            <RadzenFormField Text="Роли" HelpText="Выберите хотя бы одну роль">
-                <RadzenDropDown Data="@RoleOptions" @bind-Value="Model.Roles" Multiple="true" Style="width:100%" Name="Roles" />
+            <RadzenFormField Text="Роль" HelpText="Выберите одну роль">
+                <RadzenRadioButtonList TValue="string"
+                                        Data="@RoleOptions"
+                                        @bind-Value="Model.SelectedRole"
+                                        Name="Roles" />
             </RadzenFormField>
 
             <RadzenFormField Text="Пароль" HelpText="Оставьте пустым, чтобы не изменять">
@@ -48,6 +51,16 @@
     {
         Model ??= new UserEditModel();
         Model.Roles ??= new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(Model.SelectedRole))
+        {
+            Model.Roles = new List<string> { Model.SelectedRole };
+        }
+        else if (Model.Roles.Count > 0)
+        {
+            Model.SelectedRole = Model.Roles[0];
+            Model.Roles = new List<string> { Model.SelectedRole };
+        }
     }
 
     private Task OnValidSubmit(UserEditModel model)
@@ -59,16 +72,15 @@
             return Task.CompletedTask;
         }
 
-        var roles = model.Roles?.Where(r => !string.IsNullOrWhiteSpace(r))
-            .Select(r => r.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList() ?? new List<string>();
+        var selectedRole = model.SelectedRole?.Trim();
 
-        if (roles.Count == 0)
+        if (string.IsNullOrWhiteSpace(selectedRole))
         {
-            NotificationService.Notify(NotificationSeverity.Warning, "Пользователи", "Выберите хотя бы одну роль");
+            NotificationService.Notify(NotificationSeverity.Warning, "Пользователи", "Выберите роль");
             return Task.CompletedTask;
         }
+
+        var roles = new List<string> { selectedRole };
 
         var password = string.IsNullOrWhiteSpace(model.Password) ? null : model.Password;
         var confirm = string.IsNullOrWhiteSpace(model.ConfirmPassword) ? null : model.ConfirmPassword;
@@ -90,6 +102,7 @@
             Login = login,
             DisplayName = model.DisplayName?.Trim() ?? string.Empty,
             Roles = roles,
+            SelectedRole = selectedRole,
             Password = password
         };
 

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -666,7 +666,8 @@
         {
             Login = user.Login,
             DisplayName = user.DisplayName,
-            Roles = new List<string>(user.Roles)
+            Roles = new List<string>(user.Roles),
+            SelectedRole = user.Roles.FirstOrDefault()
         };
 
         var result = await OpenUserDialogAsync(model, false);

--- a/Scalemon.WebApp/Models/UserModels.cs
+++ b/Scalemon.WebApp/Models/UserModels.cs
@@ -30,6 +30,7 @@ public sealed class UserEditModel
     public string Login { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
     public List<string> Roles { get; set; } = new();
+    public string? SelectedRole { get; set; }
     public string? Password { get; set; }
     public string? ConfirmPassword { get; set; }
 }


### PR DESCRIPTION
## Summary
- update the user edit dialog to bind to a single selected role via radio buttons
- ensure the edit model exposes the selected role and normalises existing role lists to one entry
- persist only the chosen role when creating or updating users

## Testing
- `dotnet build Scalemon.WebApp/Scalemon.WebApp.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e65569726c832fbf05d9a6ec06e64c