### PR TITLE
Add role-based visibility helper for layout and navigation

### DIFF
--- a/Scalemon.WebApp/Auth/RoleExtensions.cs
+++ b/Scalemon.WebApp/Auth/RoleExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Scalemon.WebApp.Auth;
+
+public static class RoleExtensions
+{
+    private static readonly Dictionary<string, int> RoleRank =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["viewer"] = 0,
+            ["editor"] = 1,
+            ["admin"] = 2,
+        };
+
+    public static bool HasRoleAtLeast(this ClaimsPrincipal user, string minimumRole)
+    {
+        if (!(user.Identity?.IsAuthenticated ?? false))
+        {
+            return false;
+        }
+
+        if (!RoleRank.TryGetValue(minimumRole, out var required))
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumRole));
+        }
+
+        return user.FindAll(ClaimTypes.Role)
+                   .Select(claim => RoleRank.TryGetValue(claim.Value, out var level) ? level : -1)
+                   .Any(level => level >= required);
+    }
+}

--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
 @inherits LayoutComponentBase
 
 @inject NavigationManager Nav
@@ -7,6 +8,7 @@
 @inject CookieThemeService CookieThemeService
 @implements IAsyncDisposable
 
+<CascadingValue Value="this">
 <RadzenLayout>
 
     <!-- Верхняя панель с логотипом и общим заголовком -->
@@ -34,16 +36,14 @@
         </RadzenStack>
     </RadzenHeader>
 
-    @if (!_isLoginPage && _isAuthenticated)
-    {
-        <!-- ВАЖНО: не привязываем Expanded, держим панель всегда видимой -->
-        <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
-            <NavMenu Collapsed="@(navCollapsed)"
-                     OnToggleSidebar="ToggleSidebar"
-                     OnLogin="Login"
-                     OnLogout="Logout" />
-        </RadzenSidebar>
-    }
+    <!-- ВАЖНО: не привязываем Expanded, держим панель всегда видимой -->
+    <RadzenSidebar Visible="@_canSee('viewer')"
+                   Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
+        <NavMenu Collapsed="@(navCollapsed)"
+                 OnToggleSidebar="ToggleSidebar"
+                 OnLogin="Login"
+                 OnLogout="Logout" />
+    </RadzenSidebar>
 
     <RadzenBody>
         <div class="rz-p-3">
@@ -56,6 +56,7 @@
         <RadzenContextMenu />
     </RadzenBody>
 </RadzenLayout>
+</CascadingValue>
 
 @code {
     DotNetObjectReference<MainLayout>? _dotRef;
@@ -65,6 +66,7 @@
     private bool navCollapsed = false; // false=широкая, true=узкая рейка
     private bool _isLoginPage;
     private bool _isAuthenticated;
+    private ClaimsPrincipal? _user;
 
     [CascadingParameter]
     private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
@@ -104,11 +106,17 @@
         if (AuthenticationStateTask is not null)
         {
             var authState = await AuthenticationStateTask;
-            _isAuthenticated = authState.User.Identity?.IsAuthenticated ?? false;
+            _user = authState.User;
+            _isAuthenticated = _user.Identity?.IsAuthenticated ?? false;
         }
 
         await base.OnParametersSetAsync();
     }
+
+    private bool _canSee(string minimumRole) =>
+        _user?.HasRoleAtLeast(minimumRole) ?? false;
+
+    public bool CanSee(string minimumRole) => _canSee(minimumRole);
 
     private Task ToggleSidebar()
     {

--- a/Scalemon.WebApp/Components/Layout/NavMenu.razor
+++ b/Scalemon.WebApp/Components/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Authorization
+@using Scalemon.WebApp.Components.Layout
 
 @code {
     [Parameter] public bool Collapsed { get; set; }
@@ -7,9 +8,12 @@
     [Parameter] public EventCallback OnLogout { get; set; }
 
     [CascadingParameter] private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
+    [CascadingParameter] private MainLayout? Layout { get; set; }
 
     private bool _isAuthenticated;
     private string? _userName;
+
+    private bool _canSee(string minimumRole) => Layout?.CanSee(minimumRole) ?? false;
 
     private string ToggleIcon => Collapsed ? "keyboard_double_arrow_right" : "keyboard_double_arrow_left";
     private string ToggleText => Collapsed ? "Развернуть" : "Свернуть";
@@ -44,7 +48,7 @@
     <RadzenPanelMenu DisplayStyle="@(Collapsed? MenuItemDisplayStyle.Icon: MenuItemDisplayStyle.IconAndText)"
                      ShowArrow="false">
         <RadzenPanelMenuItem Text="Мониторинг" Icon="monitor_heart" Path="/monitoring" />
-        <RadzenPanelMenuItem Text="Логи" Icon="article" Path="/logs" />
+        <RadzenPanelMenuItem Text="Логи" Icon="article" Path="/logs" Visible="@_canSee('editor')" />
         <RadzenPanelMenuItem Text="Статистика" Icon="query_stats" Path="/statistics" />
     </RadzenPanelMenu>
 

--- a/Scalemon.WebApp/Components/_Imports.razor
+++ b/Scalemon.WebApp/Components/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
 @using Scalemon.WebApp
+@using Scalemon.WebApp.Auth
 @using Scalemon.WebApp.Components
 @using Scalemon.WebApp.Data
 @using Scalemon.WebApp.Models


### PR DESCRIPTION
## Summary
- add a ClaimsPrincipal extension to evaluate minimum role requirements
- cache the authenticated user in MainLayout, cascade the layout instance, and drive sidebar visibility via the shared helper
- hide the Logs navigation entry unless the user has at least the editor role

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e65d3a3864832fbe16ec752cdffcc3