### PR TITLE
Implement centralized role visibility helper

### DIFF
--- a/Scalemon.WebApp/Components/Auth/RoleAwareComponentBase.cs
+++ b/Scalemon.WebApp/Components/Auth/RoleAwareComponentBase.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Scalemon.WebApp.Components.Auth;
+
+internal static class RoleVisibilityEvaluator
+{
+    public static bool CanSee(ClaimsPrincipal? user, int level)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return false;
+        }
+
+        if (level <= 1)
+        {
+            return true;
+        }
+
+        var roles = user.FindAll(ClaimTypes.Role)
+            .Select(c => c.Value)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return level switch
+        {
+            2 => roles.Contains("Admin") || roles.Contains("Editor"),
+            3 => roles.Contains("Admin"),
+            _ => false
+        };
+    }
+}
+
+internal sealed class RoleVisibilityState
+{
+    private ClaimsPrincipal? _currentUser;
+
+    public ClaimsPrincipal? CurrentUser => _currentUser;
+
+    public bool IsAuthenticated => _currentUser?.Identity?.IsAuthenticated ?? false;
+
+    public bool CanSee(int level) => RoleVisibilityEvaluator.CanSee(_currentUser, level);
+
+    public void Update(ClaimsPrincipal? user)
+    {
+        _currentUser = user;
+    }
+}
+
+public abstract class RoleAwareComponentBase : ComponentBase
+{
+    private readonly RoleVisibilityState _visibility = new();
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected ClaimsPrincipal? CurrentUser => _visibility.CurrentUser;
+
+    protected bool IsAuthenticated => _visibility.IsAuthenticated;
+
+    protected bool CanSee(int level) => _visibility.CanSee(level);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (AuthenticationStateTask is not null)
+        {
+            var state = await AuthenticationStateTask;
+            _visibility.Update(state.User);
+        }
+
+        await base.OnParametersSetAsync();
+    }
+}
+
+public abstract class RoleAwareLayoutComponentBase : LayoutComponentBase
+{
+    private readonly RoleVisibilityState _visibility = new();
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected ClaimsPrincipal? CurrentUser => _visibility.CurrentUser;
+
+    protected bool IsAuthenticated => _visibility.IsAuthenticated;
+
+    protected bool CanSee(int level) => _visibility.CanSee(level);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (AuthenticationStateTask is not null)
+        {
+            var state = await AuthenticationStateTask;
+            _visibility.Update(state.User);
+        }
+
+        await base.OnParametersSetAsync();
+    }
+}

--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Authorization
-@inherits LayoutComponentBase
+@inherits RoleAwareLayoutComponentBase
 
 @inject NavigationManager Nav
 @inject IJSRuntime JS
@@ -23,21 +23,20 @@
                 <RadzenText Text="·" Class="rz-ml-1 rz-mr-1" />
                 <RadzenText Text="@_pageTitle" TextStyle="TextStyle.H6" Class="rz-text-secondary" />
             </RadzenStack>
-            @if (!_isLoginPage && !_isAuthenticated)
-            {
-                <RadzenButton Icon="login"
-                              Text="Войти"
-                              ButtonStyle="ButtonStyle.Primary"
-                              Size="ButtonSize.Small"
-                              Click="Login" />
-            }
+            <RadzenButton Icon="login"
+                          Text="Войти"
+                          ButtonStyle="ButtonStyle.Primary"
+                          Size="ButtonSize.Small"
+                          Visible="@(!_isLoginPage && !CanSee(1))"
+                          Click="Login" />
         </RadzenStack>
     </RadzenHeader>
 
-    @if (!_isLoginPage && _isAuthenticated)
+    @if (!_isLoginPage)
     {
         <!-- ВАЖНО: не привязываем Expanded, держим панель всегда видимой -->
-        <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")">
+        <RadzenSidebar Style="@(navCollapsed ? "width:64px;transition:width .2s" : "width:200px;transition:width .2s")"
+                       Visible="@CanSee(1)">
             <NavMenu Collapsed="@(navCollapsed)"
                      OnToggleSidebar="ToggleSidebar"
                      OnLogin="Login"
@@ -64,11 +63,6 @@
     private string _pageTitle = "Главная";
     private bool navCollapsed = false; // false=широкая, true=узкая рейка
     private bool _isLoginPage;
-    private bool _isAuthenticated;
-
-    [CascadingParameter]
-    private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
-
     protected override void OnInitialized()
     {
         SetPageTitle(Nav.Uri);
@@ -97,17 +91,6 @@
             _ => "Страница"
         };
         StateHasChanged();
-    }
-
-    protected override async Task OnParametersSetAsync()
-    {
-        if (AuthenticationStateTask is not null)
-        {
-            var authState = await AuthenticationStateTask;
-            _isAuthenticated = authState.User.Identity?.IsAuthenticated ?? false;
-        }
-
-        await base.OnParametersSetAsync();
     }
 
     private Task ToggleSidebar()

--- a/Scalemon.WebApp/Components/Layout/NavMenu.razor
+++ b/Scalemon.WebApp/Components/Layout/NavMenu.razor
@@ -1,34 +1,16 @@
-﻿@using Microsoft.AspNetCore.Components.Authorization
-
 @code {
     [Parameter] public bool Collapsed { get; set; }
     [Parameter] public EventCallback OnToggleSidebar { get; set; }
     [Parameter] public EventCallback OnLogin { get; set; }
     [Parameter] public EventCallback OnLogout { get; set; }
 
-    [CascadingParameter] private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
-
-    private bool _isAuthenticated;
-    private string? _userName;
-
     private string ToggleIcon => Collapsed ? "keyboard_double_arrow_right" : "keyboard_double_arrow_left";
     private string ToggleText => Collapsed ? "Развернуть" : "Свернуть";
 
+    private string? UserName => CurrentUser?.Identity?.Name;
+
     private Task ToggleMenuItemClick(MenuItemEventArgs _)
         => OnToggleSidebar.InvokeAsync();
-
-    protected override async Task OnParametersSetAsync()
-    {
-        if (AuthenticationStateTask is not null)
-        {
-            var authState = await AuthenticationStateTask;
-            var user = authState.User;
-            _isAuthenticated = user.Identity?.IsAuthenticated ?? false;
-            _userName = _isAuthenticated ? user.Identity?.Name : null;
-        }
-
-        await base.OnParametersSetAsync();
-    }
 }
 
 <!-- Вся колонка панели -->
@@ -44,7 +26,7 @@
     <RadzenPanelMenu DisplayStyle="@(Collapsed? MenuItemDisplayStyle.Icon: MenuItemDisplayStyle.IconAndText)"
                      ShowArrow="false">
         <RadzenPanelMenuItem Text="Мониторинг" Icon="monitor_heart" Path="/monitoring" />
-        <RadzenPanelMenuItem Text="Логи" Icon="article" Path="/logs" />
+        <RadzenPanelMenuItem Text="Логи" Icon="article" Path="/logs" Visible="@CanSee(2)" />
         <RadzenPanelMenuItem Text="Статистика" Icon="query_stats" Path="/statistics" />
     </RadzenPanelMenu>
 
@@ -57,29 +39,28 @@
         </RadzenPanelMenu>
 
         <div class="rz-p-2">
-            @if (_isAuthenticated)
-            {
-                <div style="display:flex;align-items:center;gap:.5rem">
-                    <RadzenIcon Icon="account_circle" />
-                    @if (!Collapsed && !string.IsNullOrWhiteSpace(_userName))
-                    {
-                        <RadzenLabel Text="@_userName" />
-                    }
-                    <RadzenButton Icon="logout"
-                                  Text="@(Collapsed ? null : "Выход")"
-                                  ButtonStyle="ButtonStyle.Secondary"
-                                  Size="ButtonSize.Small"
-                                  Click="() => OnLogout.InvokeAsync()" />
-                </div>
-            }
-            else
-            {
-                <RadzenButton Icon="login"
-                              Text="@(Collapsed ? null : "Войти")"
-                              ButtonStyle="ButtonStyle.Primary"
+            <RadzenStack Orientation="Orientation.Horizontal"
+                          AlignItems="AlignItems.Center"
+                          Gap="8"
+                          Visible="@CanSee(1)">
+                <RadzenIcon Icon="account_circle" />
+                @if (!Collapsed && !string.IsNullOrWhiteSpace(UserName))
+                {
+                    <RadzenLabel Text="@UserName" />
+                }
+                <RadzenButton Icon="logout"
+                              Text="@(Collapsed ? null : "Выход")"
+                              ButtonStyle="ButtonStyle.Secondary"
                               Size="ButtonSize.Small"
-                              Click="() => OnLogin.InvokeAsync()" />
-            }
+                              Click="() => OnLogout.InvokeAsync()" />
+            </RadzenStack>
+
+            <RadzenButton Icon="login"
+                          Text="@(Collapsed ? null : "Войти")"
+                          ButtonStyle="ButtonStyle.Primary"
+                          Size="ButtonSize.Small"
+                          Visible="@(!CanSee(1))"
+                          Click="() => OnLogin.InvokeAsync()" />
         </div>
     </div>
 </div>

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -131,7 +131,7 @@
     </RadzenTabsItem>
 
     <!-- 2) СЛУЖБА -->
-    <RadzenTabsItem Text="Служба">
+    <RadzenTabsItem Text="Служба" Visible="@CanSee(3)">
             <RadzenTemplateForm TItem="SettingsDto"
                                 Data="@Model"
                                 Submit="@OnValidSubmit"

--- a/Scalemon.WebApp/Components/_Imports.razor
+++ b/Scalemon.WebApp/Components/_Imports.razor
@@ -9,8 +9,10 @@
 @using Microsoft.JSInterop
 @using Scalemon.WebApp
 @using Scalemon.WebApp.Components
+@using Scalemon.WebApp.Components.Auth
 @using Scalemon.WebApp.Data
 @using Scalemon.WebApp.Models
 @using static Scalemon.WebApp.Models.WeighingModels
 @using Radzen
 @using Radzen.Blazor
+@inherits RoleAwareComponentBase


### PR DESCRIPTION
## Summary
- add shared role-aware base components to expose the CanSee helper throughout Razor components
- update the main layout and navigation to rely on role-based visibility instead of local authentication logic
- hide the service settings tab for non-admin roles using the centralized helper

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e66fe65550832fa66e52afe82f49d9