### PR TITLE
Handle authenticated users in redirect component

### DIFF
--- a/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
+++ b/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
@@ -1,7 +1,17 @@
 @using System
+@using Microsoft.AspNetCore.Components.Authorization
 @inject NavigationManager Nav
 
-@if (_redirectStarted)
+@if (_showAccessDenied)
+{
+    <div class="alert alert-warning">
+        <p>У вас нет доступа к этой странице.</p>
+        <p>
+            Попробуйте вернуться на <a href="/">главную страницу</a> или используйте доступные разделы приложения.
+        </p>
+    </div>
+}
+else if (_redirectStarted)
 {
     <p>Перенаправление на страницу входа...</p>
 }
@@ -12,11 +22,25 @@ else
 
 @code {
     private bool _redirectStarted;
+    private bool _showAccessDenied;
 
-    protected override void OnInitialized()
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected override async Task OnInitializedAsync()
     {
-        if (_redirectStarted)
+        if (_redirectStarted || _showAccessDenied)
         {
+            return;
+        }
+
+        var state = AuthenticationStateTask is null
+            ? null
+            : await AuthenticationStateTask;
+
+        if (state?.User?.Identity?.IsAuthenticated == true)
+        {
+            _showAccessDenied = true;
             return;
         }
 


### PR DESCRIPTION
## Summary
- obtain the cascading authentication state before redirecting anonymous visitors to the login page
- show an access denied message with navigation guidance for authenticated users who reach the redirect component

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6908c23a4832f9d84cb913766fe9f