### PR TITLE
Handle authenticated access denials without logout

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -157,13 +157,40 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.Events.OnRedirectToLogin = context =>
         {
             if (context.Request.Path.StartsWithSegments("/api"))
+            {
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            }
+            else if (context.HttpContext.User.Identity?.IsAuthenticated == true)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            }
             else
             {
                 var returnUrl = context.Request.Path + context.Request.QueryString;
                 var redirectUri = options.LoginPath + "?returnUrl=" + Uri.EscapeDataString(returnUrl);
                 context.Response.Redirect(redirectUri);
             }
+
+            return Task.CompletedTask;
+        };
+
+        options.Events.OnRedirectToAccessDenied = context =>
+        {
+            if (context.Request.Path.StartsWithSegments("/api"))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            }
+            else if (context.HttpContext.User.Identity?.IsAuthenticated == true)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            }
+            else
+            {
+                var returnUrl = context.Request.Path + context.Request.QueryString;
+                var redirectUri = options.LoginPath + "?returnUrl=" + Uri.EscapeDataString(returnUrl);
+                context.Response.Redirect(redirectUri);
+            }
+
             return Task.CompletedTask;
         };
     });

--- a/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
+++ b/Scalemon.WebApp/Components/Auth/RedirectToLogin.razor
@@ -1,7 +1,19 @@
 @using System
+@using System.Linq
+@using Microsoft.AspNetCore.Components.Authorization
 @inject NavigationManager Nav
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
-@if (_redirectStarted)
+@if (_showAccessDenied)
+{
+    <div class="alert alert-warning">
+        <p>У вас нет доступа к этой странице.</p>
+        <p>
+            Попробуйте вернуться на <a href="/">главную страницу</a> или используйте доступные разделы приложения.
+        </p>
+    </div>
+}
+else if (_redirectStarted)
 {
     <p>Перенаправление на страницу входа...</p>
 }
@@ -12,11 +24,27 @@ else
 
 @code {
     private bool _redirectStarted;
+    private bool _showAccessDenied;
 
-    protected override void OnInitialized()
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected override async Task OnParametersSetAsync()
     {
-        if (_redirectStarted)
+        if (_redirectStarted || _showAccessDenied)
         {
+            return;
+        }
+
+        var stateTask = AuthenticationStateTask ?? AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var state = await stateTask;
+
+        var isAuthenticated = state?.User?.Identities?.Any(identity => identity.IsAuthenticated) == true
+            || state?.User?.Identity?.IsAuthenticated == true;
+
+        if (isAuthenticated)
+        {
+            _showAccessDenied = true;
             return;
         }
 


### PR DESCRIPTION
## Summary
- obtain the cascading authentication state before redirecting anonymous visitors to the login page
- show an access denied message with navigation guidance for authenticated users who reach the redirect component
- stop the cookie middleware from redirecting authenticated users to the login screen when access is denied

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6908c23a4832f9d84cb913766fe9f