### PR TITLE
Adjust logs filter time range when navigating from monitoring

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -394,8 +394,34 @@
             var t = res.Success ? res.Value : null;
             if (t != null)
             {
-                from = StartOfDay(t.Date);
-                to = EndOfDay(t.Date);
+                if (t.LogsFrom is DateTime fromTs && t.LogsTo is DateTime toTs)
+                {
+                    from = fromTs;
+                    to = toTs;
+                }
+                else if (t.SelectedTimestamp is DateTime ts)
+                {
+                    double intervalSeconds = 0;
+                    if (t.PollingIntervalMs is int pollMs && pollMs > 0)
+                    {
+                        intervalSeconds = pollMs * 0.05;
+                    }
+
+                    from = ts.AddSeconds(-intervalSeconds);
+                    to = ts.AddSeconds(3);
+                }
+                else
+                {
+                    from = StartOfDay(t.Date);
+                    to = EndOfDay(t.Date);
+                }
+
+                if (from is DateTime fVal && to is DateTime tVal && fVal > tVal)
+                {
+                    var fallback = StartOfDay(t.Date);
+                    from = fallback;
+                    to = EndOfDay(t.Date);
+                }
                 await PersistDatesToSessionAsync();
                 return;
             }
@@ -498,5 +524,9 @@
         public int PageIndex { get; set; }
         public int? SelectedOrderInDay { get; set; }
         public DateTime CreatedAt { get; set; }
+        public DateTime? SelectedTimestamp { get; set; }
+        public int? PollingIntervalMs { get; set; }
+        public DateTime? LogsFrom { get; set; }
+        public DateTime? LogsTo { get; set; }
     }
 }

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -8,6 +8,7 @@
 @inject ProtectedLocalStorage PLS
 @inject IWeighingDataService Data
 @inject NavigationManager Nav
+@inject ISettingsSource SettingsSource
 
 <RadzenRow>   
 
@@ -138,6 +139,10 @@
         public int PageIndex { get; set; }               // страница (0..)
         public int? SelectedOrderInDay { get; set; }     // № взвешивания за день (1..N), может быть null
         public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime? SelectedTimestamp { get; set; }
+        public int? PollingIntervalMs { get; set; }
+        public DateTime? LogsFrom { get; set; }
+        public DateTime? LogsTo { get; set; }
     }
 
     protected override async Task OnInitializedAsync()
@@ -367,11 +372,42 @@
         var posOnPage = _grid?.GetSelectedOrderOnPage(); // 1..400 или null
         int? orderInDay = posOnPage.HasValue ? (_pageIndex * 400) + posOnPage.Value : _selectedOrderInDay;
 
+        DateTime? selectedTimestamp = _selectedCell?.Timestamp;
+        int? pollingIntervalMs = null;
+        DateTime? logsFrom = null;
+        DateTime? logsTo = null;
+
+        if (selectedTimestamp is DateTime ts)
+        {
+            try
+            {
+                var settings = await SettingsSource.LoadAsync();
+                pollingIntervalMs = settings?.ScaleSettings?.PollingIntervalMs;
+            }
+            catch
+            {
+                pollingIntervalMs = null;
+            }
+
+            double intervalSeconds = 0;
+            if (pollingIntervalMs is int pollMs && pollMs > 0)
+            {
+                intervalSeconds = pollMs * 0.05;
+            }
+
+            logsFrom = ts.AddSeconds(-intervalSeconds);
+            logsTo = ts.AddSeconds(3);
+        }
+
         var ticket = new ReturnToMonitoring
         {
             Date = SelectedDate.Date,
             PageIndex = _pageIndex,
-            SelectedOrderInDay = orderInDay
+            SelectedOrderInDay = orderInDay,
+            SelectedTimestamp = selectedTimestamp,
+            PollingIntervalMs = pollingIntervalMs,
+            LogsFrom = logsFrom,
+            LogsTo = logsTo
         };
         await PLS.SetAsync(ReturnKey, ticket);
     }


### PR DESCRIPTION
## Summary
- extend the monitoring navigation ticket with the selected timestamp and computed log time window
- calculate the log filter window using the polling interval and store it when jumping to the logs page
- restore the precise from/to values on the logs page instead of defaulting to the whole day

## Testing
- dotnet build Scalemon.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a29e51dc832fb87710e310184627