### PR TITLE
Require auth for Razor component endpoints

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -276,7 +276,8 @@ app.UseAntiforgery();
 app.MapControllers();
 
 app.MapRazorComponents<App>()
-   .AddInteractiveServerRenderMode();
+   .AddInteractiveServerRenderMode()
+   .RequireAuthorization();
 
 
 // --- 5. ЗАПУСК ПРИЛОЖЕНИЯ ---

--- a/Scalemon.WebApp/Components/Pages/About.razor
+++ b/Scalemon.WebApp/Components/Pages/About.razor
@@ -1,4 +1,5 @@
 @page "/about"
+@attribute [Authorize]
 
 <RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
     <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="Imperium Caeli" />

--- a/Scalemon.WebApp/Components/Pages/Error.razor
+++ b/Scalemon.WebApp/Components/Pages/Error.razor
@@ -1,4 +1,5 @@
 ﻿@page "/Error"
+@attribute [Authorize]
 @using System.Diagnostics
 
 <PageTitle>Error</PageTitle>

--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -1,4 +1,5 @@
 ﻿@page "/logs"
+@attribute [Authorize]
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.WebUtilities

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -1,4 +1,5 @@
 @page "/"
+@attribute [Authorize]
 
 <RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
     <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="community" />

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -1,4 +1,5 @@
 ﻿@page "/monitoring"
+@attribute [Authorize]
 @using System.Globalization
 @using Scalemon.WebApp.Models
 @using Scalemon.WebApp.Data

--- a/Scalemon.WebApp/Components/Pages/Settings.razor
+++ b/Scalemon.WebApp/Components/Pages/Settings.razor
@@ -1,4 +1,5 @@
 ﻿@page "/settings"
+@attribute [Authorize]
 @using System.Net.Http.Json
 @using System.Collections.Generic
 @using System.Threading

--- a/Scalemon.WebApp/Components/Pages/Statistics.razor
+++ b/Scalemon.WebApp/Components/Pages/Statistics.razor
@@ -1,4 +1,5 @@
 ﻿@page "/statistics"
+@attribute [Authorize]
 @rendermode InteractiveServer
 
 <PageTitle>Статистика</PageTitle>

--- a/Scalemon.WebApp/Components/Pages/_Imports.razor
+++ b/Scalemon.WebApp/Components/Pages/_Imports.razor
@@ -1,0 +1,1 @@
+@attribute [Authorize]


### PR DESCRIPTION
## Summary
- require authentication for all Razor component endpoints by default so unauthorized users hit the login redirect

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e773d9795c832fabbbc257719779c9