### PR TITLE
Enforce authentication for all pages

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -194,7 +195,12 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
             return Task.CompletedTask;
         };
     });
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
 
 // Сервисы для Blazor и Radzen UI
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();


### PR DESCRIPTION
## Summary
- require authenticated users by default via the authorization fallback policy
- keep the login page accessible to anonymous visitors while protecting all other endpoints

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e7908e44dc832fad58316a9ca04f57