### PR TITLE
Restrict anonymous access to API and UI endpoints

### DIFF
--- a/Scalemon.ServiceHost/Program.cs
+++ b/Scalemon.ServiceHost/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -194,7 +195,12 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
             return Task.CompletedTask;
         };
     });
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
 
 // Сервисы для Blazor и Radzen UI
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
@@ -273,10 +279,12 @@ app.UseAuthorization();
 app.UseAntiforgery();
 
 // Конечные точки (API и Blazor UI)
-app.MapControllers();
+var apiEndpoints = app.MapControllers();
+apiEndpoints.RequireAuthorization();
 
-app.MapRazorComponents<App>()
-   .AddInteractiveServerRenderMode();
+var razorComponents = app.MapRazorComponents<App>();
+razorComponents.AddInteractiveServerRenderMode();
+razorComponents.RequireAuthorization();
 
 
 // --- 5. ЗАПУСК ПРИЛОЖЕНИЯ ---


### PR DESCRIPTION
## Summary
- require authentication for all mapped controllers, preserving anonymous login access through `[AllowAnonymous]`
- enforce authorization for the Razor component endpoints while relying on the login page's `[AllowAnonymous]` attribute as the sole public entry point

## Testing
- not run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e7908e44dc832fad58316a9ca04f57