### PR TITLE
Update layout header and redesign dashboard cards

### DIFF
--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor
@@ -20,16 +20,27 @@
                          AlignItems="AlignItems.Center"
                          Gap="8">
                 <RadzenImage Path="_content/Scalemon.WebApp/images/logo-main.png" Style="width:24px;height:24px" />
-                <RadzenText Text="ScaleMonitoring" TextStyle="TextStyle.H5" />
+                <RadzenLink Path="/" Style="text-decoration:none;color:inherit">
+                    <RadzenText Text="ScaleMonitoring" TextStyle="TextStyle.H5" />
+                </RadzenLink>
                 <RadzenText Text="·" Class="rz-ml-1 rz-mr-1" />
                 <RadzenText Text="@_pageTitle" TextStyle="TextStyle.H6" Class="rz-text-secondary" />
             </RadzenStack>
-            <RadzenButton Icon="login"
-                          Text="Войти"
-                          ButtonStyle="ButtonStyle.Primary"
-                          Size="ButtonSize.Small"
-                          Visible="@(!_isLoginPage && !CanSee(1))"
-                          Click="Login" />
+            <RadzenStack Orientation="Orientation.Horizontal"
+                          AlignItems="AlignItems.Center"
+                          Gap="8"
+                          Visible="@(!_isLoginPage && CanSee(1))">
+                <RadzenIcon Icon="account_circle" Style="font-size:28px" />
+                @if (!string.IsNullOrWhiteSpace(UserName))
+                {
+                    <RadzenText Text="@UserName" TextStyle="TextStyle.Subtitle1" Class="rz-text-nowrap" />
+                }
+                <RadzenButton Icon="logout"
+                              Text="Выход"
+                              ButtonStyle="ButtonStyle.Secondary"
+                              Size="ButtonSize.Small"
+                              Click="Logout" />
+            </RadzenStack>
         </RadzenStack>
     </RadzenHeader>
 
@@ -78,6 +89,7 @@
     private string _pageTitle = "Главная";
     private bool navCollapsed = false; // false=широкая, true=узкая рейка
     private bool _isLoginPage;
+    private string? UserName => CurrentUser?.Identity?.Name;
     protected override void OnInitialized()
     {
         SetPageTitle(Nav.Uri);

--- a/Scalemon.WebApp/Components/Layout/NavMenu.razor
+++ b/Scalemon.WebApp/Components/Layout/NavMenu.razor
@@ -7,21 +7,12 @@
     private string ToggleIcon => Collapsed ? "keyboard_double_arrow_right" : "keyboard_double_arrow_left";
     private string ToggleText => Collapsed ? "Развернуть" : "Свернуть";
 
-    private string? UserName => CurrentUser?.Identity?.Name;
-
     private Task ToggleMenuItemClick(MenuItemEventArgs _)
         => OnToggleSidebar.InvokeAsync();
 }
 
 <!-- Вся колонка панели -->
 <div style="height:100%;display:flex;flex-direction:column">
-
-    <RadzenPanelMenu DisplayStyle="@(Collapsed? MenuItemDisplayStyle.Icon: MenuItemDisplayStyle.IconAndText)"
-                     ShowArrow="false">
-        <RadzenPanelMenuItem Text="@ToggleText"
-                             Icon="@ToggleIcon"
-                             Click="@ToggleMenuItemClick" />
-    </RadzenPanelMenu>
 
     <RadzenPanelMenu DisplayStyle="@(Collapsed? MenuItemDisplayStyle.Icon: MenuItemDisplayStyle.IconAndText)"
                      ShowArrow="false">
@@ -38,29 +29,12 @@
             <RadzenPanelMenuItem Text="О программе" Icon="help" Path="/about" />
         </RadzenPanelMenu>
 
-        <div class="rz-p-2">
-            <RadzenStack Orientation="Orientation.Horizontal"
-                          AlignItems="AlignItems.Center"
-                          Gap="8"
-                          Visible="@CanSee(1)">
-                <RadzenIcon Icon="account_circle" />
-                @if (!Collapsed && !string.IsNullOrWhiteSpace(UserName))
-                {
-                    <RadzenLabel Text="@UserName" />
-                }
-                <RadzenButton Icon="logout"
-                              Text="@(Collapsed ? null : "Выход")"
-                              ButtonStyle="ButtonStyle.Secondary"
-                              Size="ButtonSize.Small"
-                              Click="() => OnLogout.InvokeAsync()" />
-            </RadzenStack>
-
-            <RadzenButton Icon="login"
-                          Text="@(Collapsed ? null : "Войти")"
-                          ButtonStyle="ButtonStyle.Primary"
-                          Size="ButtonSize.Small"
-                          Visible="@(!CanSee(1))"
-                          Click="() => OnLogin.InvokeAsync()" />
-        </div>
+        <RadzenPanelMenu DisplayStyle="@(Collapsed? MenuItemDisplayStyle.Icon: MenuItemDisplayStyle.IconAndText)"
+                         ShowArrow="false"
+                         Class="rz-mt-2">
+            <RadzenPanelMenuItem Text="@ToggleText"
+                                 Icon="@ToggleIcon"
+                                 Click="@ToggleMenuItemClick" />
+        </RadzenPanelMenu>
     </div>
 </div>

--- a/Scalemon.WebApp/Components/Pages/Main.razor
+++ b/Scalemon.WebApp/Components/Pages/Main.razor
@@ -1,7 +1,44 @@
 @page "/"
 @attribute [Authorize]
 
-<RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
-    <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="community" />
-    <RadzenText TextStyle="TextStyle.DisplayH3">Главная страница с логином</RadzenText>
+<RadzenStack Orientation="Orientation.Vertical"
+             AlignItems="AlignItems.Center"
+             Gap="24"
+             Class="rz-mx-auto rz-my-8"
+             Style="max-width:960px">
+    <RadzenStack Orientation="Orientation.Horizontal"
+                  Gap="24"
+                  JustifyContent="JustifyContent.Center">
+        @CardLink("/monitoring", "monitor_heart", "Мониторинг", "Просматривайте ключевые показатели и статусы оборудования в режиме реального времени.")
+        @CardLink("/logs", "article", "Логи", "Анализируйте журнал событий и выявляйте ошибки службы Scalemon.")
+    </RadzenStack>
+
+    <RadzenStack Orientation="Orientation.Horizontal"
+                  Gap="24"
+                  JustifyContent="JustifyContent.Center">
+        @CardLink("/statistics", "query_stats", "Статистика", "Оценивайте динамику показателей и находите тенденции работы системы.")
+        @CardLink("/settings", "settings", "Настройки", "Управляйте параметрами измерительного комплекса и пользовательскими предпочтениями.")
+    </RadzenStack>
+
+    <RadzenStack Orientation="Orientation.Horizontal"
+                  Gap="24"
+                  JustifyContent="JustifyContent.Center">
+        @CardLink("/about", "help", "О программе", "Узнайте подробности о платформе ScaleMonitoring и её возможностях.")
+    </RadzenStack>
 </RadzenStack>
+
+@code {
+    private RenderFragment CardLink(string path, string icon, string title, string description) => @<RadzenLink Path="@path" Style="text-decoration:none;color:inherit">
+        <RadzenCard Class="rz-elevation-3 rz-text-center"
+                    Style="width:240px;height:220px;display:flex;align-items:center;justify-content:center">
+            <RadzenStack Orientation="Orientation.Vertical"
+                          AlignItems="AlignItems.Center"
+                          Gap="12"
+                          Class="rz-text-center">
+                <RadzenIcon Icon="@icon" Style="font-size:48px" Class="rz-text-primary" />
+                <RadzenText Text="@title" TextStyle="TextStyle.H5" />
+                <RadzenText Text="@description" TextStyle="TextStyle.Body2" Class="rz-text-secondary" />
+            </RadzenStack>
+        </RadzenCard>
+    </RadzenLink>;
+}


### PR DESCRIPTION
## Summary
- move the authenticated user display and logout action into the main header and link the brand title to the home page
- relocate the sidebar collapse control to the footer of the navigation menu
- replace the main page hero text with Radzen cards linking to the key application sections

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7c6390978832faa6f0e7dcab0cb80