### PR TITLE
Revamp About page layout with Radzen components

### DIFF
--- a/Scalemon.WebApp/Components/Pages/About.razor
+++ b/Scalemon.WebApp/Components/Pages/About.razor
@@ -1,7 +1,109 @@
 @page "/about"
 @attribute [Authorize]
 
-<RadzenStack AlignItems="AlignItems.Center" class="rz-mx-auto rz-my-12">
-    <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="width: 15rem;" AlternateText="Imperium Caeli" />
-    <RadzenText TextStyle="TextStyle.DisplayH3">Здесь будет описание программы и рекламный текст</RadzenText>
+<RadzenStack AlignItems="AlignItems.Stretch" Gap="24px" Class="rz-mx-auto rz-my-8 rz-px-4" Style="max-width: 960px;">
+    <RadzenHeading Size="HeadingSize.H1" TextAlign="TextAlign.Left">
+        О программно-аппаратном комплексе "Scalemon"
+    </RadzenHeading>
+
+    <RadzenParagraph>
+        <strong>Scalemon</strong> — это современная система для автоматизации сбора, хранения и анализа данных с весового оборудования. Комплекс предназначен для повышения эффективности и прозрачности процессов взвешивания на производстве, складах и в логистических центрах.
+    </RadzenParagraph>
+    <RadzenParagraph>
+        Система в режиме реального времени получает данные с весов, обрабатывает их и предоставляет пользователям удобный веб-интерфейс для мониторинга и анализа.
+    </RadzenParagraph>
+
+    <RadzenDivider />
+
+    <RadzenHeading Size="HeadingSize.H3" TextAlign="TextAlign.Left">
+        Ключевые возможности и разделы интерфейса
+    </RadzenHeading>
+    <RadzenParagraph>
+        Наш интуитивно понятный веб-интерфейс позволяет вам легко управлять всеми аспектами процесса взвешивания.
+    </RadzenParagraph>
+
+    <RadzenRow Gutter="20">
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard Style="height: 100%;">
+                <ChildContent>
+                    <RadzenStack Gap="8px">
+                        <RadzenHeading Size="HeadingSize.H4">📈 Мониторинг</RadzenHeading>
+                        <RadzenText>Просмотр текущих показаний весов в режиме реального времени.</RadzenText>
+                        <RadzenText>Отслеживание статуса подключения оборудования.</RadzenText>
+                        <RadzenText>Визуализация динамики веса на графиках.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard Style="height: 100%;">
+                <ChildContent>
+                    <RadzenStack Gap="8px">
+                        <RadzenHeading Size="HeadingSize.H4">📊 Статистика</RadzenHeading>
+                        <RadzenText>Формирование отчетов по взвешиваниям за любой период.</RadzenText>
+                        <RadzenText>Анализ данных с помощью интерактивных диаграмм и таблиц.</RadzenText>
+                        <RadzenText>Выгрузка данных в форматах CSV и PDF для дальнейшего анализа.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard Style="height: 100%;">
+                <ChildContent>
+                    <RadzenStack Gap="8px">
+                        <RadzenHeading Size="HeadingSize.H4">🗂️ Журналы событий</RadzenHeading>
+                        <RadzenText>Просмотр системных логов для диагностики и контроля работы комплекса.</RadzenText>
+                        <RadzenText>Фильтрация событий по дате, типу и важности.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard Style="height: 100%;">
+                <ChildContent>
+                    <RadzenStack Gap="8px">
+                        <RadzenHeading Size="HeadingSize.H4">⚙️ Настройки</RadzenHeading>
+                        <RadzenText>Управление параметрами подключения к весовому оборудованию.</RadzenText>
+                        <RadzenText>Настройка пороговых значений и уведомлений.</RadzenText>
+                        <RadzenText>Администрирование пользователей и их прав доступа.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+    </RadzenRow>
+
+    <RadzenDivider />
+
+    <RadzenRow AlignItems="Stretch" Gutter="20">
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard>
+                <ChildContent>
+                    <RadzenStack Gap="12px" AlignItems="AlignItems.Center">
+                        <RadzenHeading Size="HeadingSize.H4">Заказчик</RadzenHeading>
+                        <RadzenImage Path="_content/Scalemon.WebApp/images/logo.png" Style="max-width: 10rem;" AlternateText="Imperium Caeli" />
+                        <RadzenText TextStyle="TextStyle.Subtitle1">ТОО "Imperium Caeli"</RadzenText>
+                        <RadzenText Style="font-style: italic;">Надежный партнер в автоматизации бизнеса.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+        <RadzenColumn SizeMD="6" SizeXS="12">
+            <RadzenCard>
+                <ChildContent>
+                    <RadzenStack Gap="12px" AlignItems="AlignItems.Center">
+                        <RadzenHeading Size="HeadingSize.H4">Разработчик</RadzenHeading>
+                        <RadzenImage Path="_content/Scalemon.WebApp/images/logo-main.png" Style="max-width: 10rem;" AlternateText="Solve.kz" />
+                        <RadzenText TextStyle="TextStyle.Subtitle1">ИП Приходько П. С. (Solve.kz)</RadzenText>
+                        <RadzenText Style="font-style: italic;">Профессиональные программные решения.</RadzenText>
+                    </RadzenStack>
+                </ChildContent>
+            </RadzenCard>
+        </RadzenColumn>
+    </RadzenRow>
+
+    <RadzenStack Gap="8px" AlignItems="AlignItems.Start">
+        <RadzenText TextStyle="TextStyle.Subtitle1">Программно-аппаратный комплекс "Scalemon"</RadzenText>
+        <RadzenText>Версия 1.0.0</RadzenText>
+        <RadzenText>© 2025. Все права защищены.</RadzenText>
+    </RadzenStack>
 </RadzenStack>


### PR DESCRIPTION
## Summary
- replace the About page placeholder with the full marketing content structured using Radzen components
- add feature cards and partner information with branding to reflect the requested layout

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e7e75cd984832f99b98558a7446765