### PR TITLE
fix: correct local timestamps in weighing audit log

### DIFF
--- a/Scalemon.WebApp/Data/Scripts/CreateWeighingEdits.sql
+++ b/Scalemon.WebApp/Data/Scripts/CreateWeighingEdits.sql
@@ -6,7 +6,7 @@ BEGIN
     (
         [Id] INT IDENTITY(1,1) NOT NULL CONSTRAINT [PK_WeighingEdits] PRIMARY KEY,
         [WeighingId] INT NOT NULL,
-        [EditedAt] DATETIME2(3) NOT NULL CONSTRAINT [DF_WeighingEdits_EditedAt] DEFAULT (SYSUTCDATETIME()),
+        [EditedAt] DATETIME2(3) NOT NULL CONSTRAINT [DF_WeighingEdits_EditedAt] DEFAULT (SYSDATETIME()),
         [EditedBy] NVARCHAR(256) NULL,
         [Action] NVARCHAR(32) NOT NULL,
         [OldWeight] DECIMAL(18,2) NULL,

--- a/Scalemon.WebApp/Data/SqlWeighingDataService.cs
+++ b/Scalemon.WebApp/Data/SqlWeighingDataService.cs
@@ -101,7 +101,7 @@ VALUES (@id,@editedAt,@editedBy,@action,@oldWeight,@newWeight,@recordedAt,@comme
 
         await using var cmd = new SqlCommand(sql, conn, tx);
         cmd.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = weighingId });
-        cmd.Parameters.Add(new SqlParameter("@editedAt", SqlDbType.DateTime2) { Value = DateTime.UtcNow });
+        cmd.Parameters.Add(new SqlParameter("@editedAt", SqlDbType.DateTime2) { Value = DateTime.Now });
         cmd.Parameters.Add(CreateString("@editedBy", editedBy, 256));
         cmd.Parameters.Add(CreateString("@action", action.ToString(), 32));
         cmd.Parameters.Add(CreateDecimal("@oldWeight", oldWeight));

--- a/Scalemon.WebApp/Data/WeighingDataService.cs
+++ b/Scalemon.WebApp/Data/WeighingDataService.cs
@@ -73,7 +73,7 @@ namespace Scalemon.WebApp.Data
                     AddAuditEntry(day, new WeighingEditEntry(
                         NextEditId(),
                         w.Id,
-                        DateTime.UtcNow,
+                        DateTime.Now,
                         userName,
                         delta >= 0 ? WeighingEditAction.Increment : WeighingEditAction.Decrement,
                         w.Weight,
@@ -113,7 +113,7 @@ namespace Scalemon.WebApp.Data
                     AddAuditEntry(day, new WeighingEditEntry(
                         NextEditId(),
                         item.Id,
-                        DateTime.UtcNow,
+                        DateTime.Now,
                         userName,
                         WeighingEditAction.Delete,
                         item.Weight,
@@ -149,7 +149,7 @@ namespace Scalemon.WebApp.Data
                 AddAuditEntry(day, new WeighingEditEntry(
                     NextEditId(),
                     item.Id,
-                    DateTime.UtcNow,
+                    DateTime.Now,
                     userName,
                     WeighingEditAction.Insert,
                     null,


### PR DESCRIPTION
## Summary
- switch weighing edit audit writes to use local server time so the saved timestamp matches user expectations
- update the in-memory weighing data service to record local edit times for consistency in dev mode
- adjust the WeighingEdits table creation script to default EditedAt to SYSDATETIME()

## Testing
- not run (not supported in Codex environment)

## How to run locally
- dotnet build Scalemon.WebApp
- dotnet run --project Scalemon.WebApp

------
https://chatgpt.com/codex/tasks/task_e_68e83389986c832fb28d470699350215