### PR TITLE
fix: highlight edited cells in weights grid

### DIFF
--- a/Scalemon.WebApp/Components/Layout/MainLayout.razor.css
+++ b/Scalemon.WebApp/Components/Layout/MainLayout.razor.css
@@ -53,8 +53,11 @@
     }
 
     .weights-grid .cell.has {
-        background: var(--rz-base-100);
         border-radius: 6px;
+    }
+
+    .weights-grid .cell.has:not(.weights-grid__cell--adjust):not(.weights-grid__cell--insert) {
+        background: var(--rz-base-100);
     }
 
 .totals-row {
@@ -91,7 +94,7 @@
     padding: 6px 8px;
 }
 
-/* Адаптивность */
+/* ГЂГ¤Г ГЇГІГЁГўГ­Г®Г±ГІГј */
 @media (max-width: 1200px) {
     .main-grid {
         grid-template-columns: 300px 1fr;

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -33,11 +33,19 @@
                     <Template Context="vm">
                         @{
                             var cell = GetCell(vm.Row, colIndex); // vm.Row — это GridRow
+                            var css = $"cell {(cell?.HasValue == true ? "has" : "empty")}";
+                            var timestamp = cell?.Timestamp?.ToString("HH:mm:ss");
+                            var weight = cell?.Weight?.ToString("0.00");
                         }
-                        <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)"
-                             title="@cell?.Timestamp?.ToString("HH:mm:ss")"><b>
-                            @cell?.Weight?.ToString("0.00")</b>
-                        </div>
+                        <RadzenConditionalTemplate Condition="@IsAdjustment(cell)">
+                            <div class="@($"{css} last-edit-adjust")" title="@timestamp"><b>@weight</b></div>
+                        </RadzenConditionalTemplate>
+                        <RadzenConditionalTemplate Condition="@IsInsertion(cell)">
+                            <div class="@($"{css} last-edit-insert")" title="@timestamp"><b>@weight</b></div>
+                        </RadzenConditionalTemplate>
+                        <RadzenConditionalTemplate>
+                            <div class="@css" title="@timestamp"><b>@weight</b></div>
+                        </RadzenConditionalTemplate>
                     </Template>
                     <FooterTemplate>
                     @(Totals is { Length: >= 10 }
@@ -204,6 +212,7 @@ else
             args.Attributes["style"] = (args.Attributes.TryGetValue("style", out var style) ? style + ";" : "")
                                      + "cursor:pointer;"; // или "cursor:crosshair;", "cursor:default;" и т.п.
         }
+
         // сравниваем с GridRowVm.No
         if (_selectedCellPos is { } pos && pos.Row == args.Data.No && pos.Col == colIndex)
         {
@@ -249,13 +258,6 @@ else
         return InvokeAsync(StateHasChanged);
     }
 
-    static string GetHighlightClass(Cell? cell) => cell?.LastEditAction switch
-    {
-        WeighingEditAction.Increment or WeighingEditAction.Decrement => "last-edit-adjust",
-        WeighingEditAction.Insert => "last-edit-insert",
-        _ => string.Empty
-    };
-
     static Cell? GetCell(GridRow row, int col) => col switch
     {
         1 => row.C1,
@@ -270,6 +272,12 @@ else
         10 => row.C10,
         _ => null
     };
+
+    static bool IsAdjustment(Cell? cell)
+        => cell?.LastEditAction is WeighingEditAction.Increment or WeighingEditAction.Decrement;
+
+    static bool IsInsertion(Cell? cell)
+        => cell?.LastEditAction is WeighingEditAction.Insert;
 
     public async Task GoToPageAsync(int pageIndex)
     {

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -33,18 +33,24 @@
                     <Template Context="vm">
                         @{
                             var cell = GetCell(vm.Row, colIndex); // vm.Row — это GridRow
-                            var css = $"cell {(cell?.HasValue == true ? "has" : "empty")}";
+                            var css = $"weights-grid__cell cell {(cell?.HasValue == true ? "has" : "empty")}";
                             var timestamp = cell?.Timestamp?.ToString("HH:mm:ss");
                             var weight = cell?.Weight?.ToString("0.00");
                         }
                         <RadzenConditionalTemplate Condition="@IsAdjustment(cell)">
-                            <div class="@($"{css} last-edit-adjust")" title="@timestamp"><b>@weight</b></div>
+                            <div class="@($"{css} weights-grid__cell--adjust")" title="@timestamp">
+                                <b>@weight</b>
+                            </div>
                         </RadzenConditionalTemplate>
                         <RadzenConditionalTemplate Condition="@IsInsertion(cell)">
-                            <div class="@($"{css} last-edit-insert")" title="@timestamp"><b>@weight</b></div>
+                            <div class="@($"{css} weights-grid__cell--insert")" title="@timestamp">
+                                <b>@weight</b>
+                            </div>
                         </RadzenConditionalTemplate>
                         <RadzenConditionalTemplate>
-                            <div class="@css" title="@timestamp"><b>@weight</b></div>
+                            <div class="@css" title="@timestamp">
+                                <b>@weight</b>
+                            </div>
                         </RadzenConditionalTemplate>
                     </Template>
                     <FooterTemplate>

--- a/Scalemon.WebApp/wwwroot/app.css
+++ b/Scalemon.WebApp/wwwroot/app.css
@@ -1,7 +1,7 @@
-.cell.last-edit-adjust {
+.rz-data-grid .last-edit-adjust {
     background-color: #ffe6f3;
 }
 
-.cell.last-edit-insert {
+.rz-data-grid .last-edit-insert {
     background-color: #e6ffe6;
 }

--- a/Scalemon.WebApp/wwwroot/app.css
+++ b/Scalemon.WebApp/wwwroot/app.css
@@ -1,7 +1,15 @@
-.rz-data-grid .last-edit-adjust {
+.weights-grid .cell.weights-grid__cell--adjust,
+.weights-grid .cell.weights-grid__cell--insert {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+.weights-grid .cell.weights-grid__cell--adjust {
     background-color: #ffe6f3;
 }
 
-.rz-data-grid .last-edit-insert {
+.weights-grid .cell.weights-grid__cell--insert {
     background-color: #e6ffe6;
 }


### PR DESCRIPTION
## Summary
- align the `WeightsGrid` cell template with Radzen conditional templates so adjusted weights and insertions receive their own background colors
- add CSS helpers to stretch the highlighted cells while keeping the default appearance for untouched values

## Testing
- not run (container image is missing .NET 8). Please run locally with `dotnet build Scalemon.sln`.

------
https://chatgpt.com/codex/tasks/task_e_68e8423cb360832f92ac4bdc04c7a29a