### PR TITLE
fix: adjust weight cell highlight colors

### DIFF
--- a/Scalemon.WebApp/wwwroot/app.css
+++ b/Scalemon.WebApp/wwwroot/app.css
@@ -1,7 +1,7 @@
 .cell.last-edit-adjust {
-    background-color: #ffe6f3;
+    background-color: #ffd6eb;
 }
 
 .cell.last-edit-insert {
-    background-color: #e6ffe6;
+    background-color: #d6ecff;
 }


### PR DESCRIPTION
## Summary
- update the highlight colors for adjusted and manually inserted weights to make them visually distinct in the Radzen grid

## Testing
- not run (cloud environment without .NET SDK)

## References
- https://blazor.radzen.com/datagrid-conditional-template

## Local verification
1. `dotnet restore`
2. `dotnet build Scalemon.sln`


------
https://chatgpt.com/codex/tasks/task_e_68e84691efbc832fbb94acba655538dd