### PR TITLE
fix(webapp): restore weights grid cell highlighting

### DIFF
--- a/Scalemon.WebApp/Components/WeightsGrid.razor.css
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor.css
@@ -1,23 +1,23 @@
-﻿/* внутренний див не должен перекрывать фон td */
-.rz-data-grid .cell {
+/* внутренний див не должен перекрывать фон td */
+::deep .rz-data-grid .cell {
     background: transparent; /* важно! */
 }
 
 /* Фоны наборов — применяются к <td> */
-.rz-data-grid td.cell-group-a {
+::deep .rz-data-grid td.cell-group-a {
     background-color: #f5fbff; /* нежно-голубой */
 }
 
-.rz-data-grid td.cell-group-b {
+::deep .rz-data-grid td.cell-group-b {
     background-color: #fff8f2; /* нежно-оранжевый */
 }
 
-.rz-data-grid td.cell-empty {
+::deep .rz-data-grid td.cell-empty {
     background-color: #f3f3f3; /* серый для пустых */
 }
 
 /* Выделение выбранной ячейки — поверх всего */
-.rz-data-grid td.cell-selected {
+::deep .rz-data-grid td.cell-selected {
     background-color: #ffe0b2 !important; /* мягкий оранжевый */
     box-shadow: inset 0 0 0 2px rgba(0,0,0,.05);
 }


### PR DESCRIPTION
## Summary
- allow Radzen DataGrid cell classes from `CellRender` to apply by using `::deep` selectors in the isolated stylesheet

## Testing
- not run (per repository instructions)

## Local run
- dotnet build Scalemon.WebApp
- dotnet run --project Scalemon.WebApp


------
https://chatgpt.com/codex/tasks/task_e_68e84c254950832f8f021bfe4311821d