### PR TITLE
fix(webapp): highlight active data grid cell over edit tint

### DIFF
--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -34,7 +34,7 @@
                         @{
                             var cell = GetCell(vm.Row, colIndex); // vm.Row — это GridRow
                         }
-                        <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)"
+                        <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)@(IsCellSelected(vm.No, colIndex) ? " cell-selected" : string.Empty)"
                              title="@cell?.Timestamp?.ToString("HH:mm:ss")"><b>
                             @cell?.Weight?.ToString("0.00")</b>
                         </div>
@@ -212,19 +212,28 @@ else
 
     string GetCellClass(GridRowVm vm, int colIndex)
     {
-        // выделенная ячейка
-        if (_selectedCellPos is { } pos && pos.Row == vm.No && pos.Col == colIndex)
-            return "cell-selected";
+        var classes = new List<string>();
 
-        // содержимое ячейки
         var cell = GetCell(vm.Row, colIndex);
         if (cell is null || !cell.HasValue)
-            return "cell-empty";
+        {
+            classes.Add("cell-empty");
+        }
+        else
+        {
+            // Разделяем на два набора по колонкам:
+            // 1..5 — набор A, 6..10 — набор B (пример, меняйте логику по своему условию)
+            classes.Add(colIndex <= 5 ? "cell-group-a" : "cell-group-b");
+        }
 
-        // Разделяем на два набора по колонкам:
-        // 1..5 — набор A, 6..10 — набор B (пример, меняйте логику по своему условию)
-        return colIndex <= 5 ? "cell-group-a" : "cell-group-b";
+        if (IsCellSelected(vm.No, colIndex))
+            classes.Add("cell-selected");
+
+        return string.Join(' ', classes);
     }
+
+    bool IsCellSelected(int rowNo, int colIndex)
+        => _selectedCellPos is { } pos && pos.Row == rowNo && pos.Col == colIndex;
 
     [JSInvokable("CloseContextMenu")]
     public Task CloseContextMenu()

--- a/Scalemon.WebApp/Components/WeightsGrid.razor.css
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor.css
@@ -1,23 +1,30 @@
-﻿/* внутренний див не должен перекрывать фон td */
-.rz-data-grid .cell {
+/* внутренний див не должен перекрывать фон td */
+::deep .rz-data-grid .cell {
     background: transparent; /* важно! */
 }
 
 /* Фоны наборов — применяются к <td> */
-.rz-data-grid td.cell-group-a {
+::deep .rz-data-grid td.cell-group-a {
     background-color: #f5fbff; /* нежно-голубой */
 }
 
-.rz-data-grid td.cell-group-b {
+::deep .rz-data-grid td.cell-group-b {
     background-color: #fff8f2; /* нежно-оранжевый */
 }
 
-.rz-data-grid td.cell-empty {
+::deep .rz-data-grid td.cell-empty {
     background-color: #f3f3f3; /* серый для пустых */
 }
 
 /* Выделение выбранной ячейки — поверх всего */
-.rz-data-grid td.cell-selected {
+::deep .rz-data-grid td.cell-selected {
     background-color: #ffe0b2 !important; /* мягкий оранжевый */
     box-shadow: inset 0 0 0 2px rgba(0,0,0,.05);
+}
+
+/* Когда внутри есть цвет (редактированная ячейка) — подсветим рамкой по div */
+::deep .rz-data-grid .cell.cell-selected.last-edit-adjust,
+::deep .rz-data-grid .cell.cell-selected.last-edit-insert {
+    box-shadow: inset 0 0 0 2px rgba(255, 152, 0, 0.7);
+    border-radius: 2px;
 }


### PR DESCRIPTION
## Summary
- add an `IsCellSelected` helper to reuse the selected state in both the Radzen `td` class and the inner cell div
- keep the edited-cell tint while restoring the active cell highlight by outlining selected edited cells in the component CSS

## Testing
- not run (per repository instructions)

## Docs
- https://blazor.radzen.com/datagrid-cellrender

------
https://chatgpt.com/codex/tasks/task_e_68e84c254950832f8f021bfe4311821d