### PR TITLE
feat(monitoring): confirm data before inserting weighing entry

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -1,0 +1,126 @@
+@using System.Globalization
+@using Scalemon.WebApp.Models
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+<RadzenTemplateForm TItem="WeighingInsertDialog.FormModel" Data="@Model" Submit="@OnValidSubmit">
+    <RadzenFieldset>
+        <RadzenStack Gap="12px">
+            <RadzenFormField Text="Вес, кг" HelpText="Введите вес с точностью до сотых">
+                <RadzenTextBox @bind-Value="Model.WeightText" Name="Weight" Style="width:100%" />
+                <RadzenRequiredValidator Component="Weight" Text="Укажите вес" />
+            </RadzenFormField>
+
+            <RadzenFormField Text="Время" HelpText="Укажите точное время фиксации">
+                <RadzenTimePicker @bind-Value="Model.Time"
+                                   Name="RecordedAt"
+                                   TimeFormat="HH:mm:ss"
+                                   ShowSeconds="true"
+                                   HoursStep="1"
+                                   MinutesStep="1"
+                                   SecondsStep="1"
+                                   Style="width:100%" />
+                <RadzenRequiredValidator Component="RecordedAt" Text="Укажите время" />
+            </RadzenFormField>
+        </RadzenStack>
+    </RadzenFieldset>
+
+    <RadzenStack Orientation="Orientation.Horizontal" Gap="8px" Style="margin-top:16px">
+        <RadzenButton Text="ОК" Icon="check" ButtonStyle="ButtonStyle.Primary" ButtonType="ButtonType.Submit" />
+        <RadzenButton Text="Отмена" Icon="close" Click="@OnCancel" />
+    </RadzenStack>
+</RadzenTemplateForm>
+
+@code {
+    [Parameter] public decimal? InitialWeight { get; set; }
+    [Parameter] public DateTime? InitialTimestamp { get; set; }
+    [Parameter] public DateTime SelectedDate { get; set; }
+
+    FormModel Model { get; set; } = new();
+
+    protected override void OnParametersSet()
+    {
+        Model ??= new FormModel();
+
+        if (string.IsNullOrWhiteSpace(Model.WeightText) && InitialWeight is decimal weight)
+        {
+            Model.WeightText = weight.ToString("0.00", CultureInfo.CurrentCulture);
+        }
+
+        if (Model.Time is null)
+        {
+            var baseTimestamp = InitialTimestamp ?? SelectedDate;
+            var normalized = SelectedDate.Date.Add(baseTimestamp.TimeOfDay);
+            Model.Time = normalized;
+        }
+    }
+
+    Task OnValidSubmit(FormModel model)
+    {
+        if (!TryParseWeight(model.WeightText, out var weight))
+        {
+            NotificationService.Notify(NotificationSeverity.Warning, "Добавление взвешивания", "Не удалось распознать вес. Используйте формат 12,34");
+            return Task.CompletedTask;
+        }
+
+        if (model.Time is null)
+        {
+            NotificationService.Notify(NotificationSeverity.Warning, "Добавление взвешивания", "Укажите время");
+            return Task.CompletedTask;
+        }
+
+        var timestamp = SelectedDate.Date.Add(model.Time.Value.TimeOfDay);
+        var rounded = Math.Round(weight, 2, MidpointRounding.AwayFromZero);
+
+        DialogService.Close(new WeighingModels.WeighingInsertRequest(rounded, timestamp));
+        return Task.CompletedTask;
+    }
+
+    void OnCancel()
+    {
+        DialogService.Close(null);
+    }
+
+    static bool TryParseWeight(string? input, out decimal value)
+    {
+        value = 0m;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var trimmed = input.Trim();
+        var sanitized = trimmed.Replace(" ", string.Empty);
+
+        if (decimal.TryParse(sanitized, NumberStyles.Number, CultureInfo.CurrentCulture, out value))
+        {
+            return true;
+        }
+
+        if (decimal.TryParse(sanitized, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+
+        var normalized = sanitized.Replace(',', '.');
+        if (decimal.TryParse(normalized, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+
+        normalized = sanitized.Replace('.', ',');
+        var ruCulture = CultureInfo.GetCultureInfo("ru-RU");
+        if (decimal.TryParse(normalized, NumberStyles.Number, ruCulture, out value))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public sealed class FormModel
+    {
+        public string? WeightText { get; set; }
+        public DateTime? Time { get; set; }
+    }
+}

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -1,15 +1,18 @@
 ﻿@page "/monitoring"
 @attribute [Authorize]
+@using System.Collections.Generic
 @using System.Globalization
 @using Scalemon.WebApp.Models
 @using Scalemon.WebApp.Data
 @using static Scalemon.WebApp.Models.WeighingModels
 @using Microsoft.AspNetCore.WebUtilities
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@using Scalemon.WebApp.Components.Dialogs
 @inject ProtectedLocalStorage PLS
 @inject IWeighingDataService Data
 @inject NavigationManager Nav
 @inject ISettingsSource SettingsSource
+@inject DialogService DialogService
 
 <RadzenRow>   
 
@@ -425,6 +428,35 @@
         await PLS.SetAsync(ReturnKey, ticket);
     }
     
+    async Task<WeighingInsertRequest?> OpenInsertDialogAsync(string action)
+    {
+        if (_selectedCell?.Timestamp is not DateTime baseTimestamp)
+        {
+            return null;
+        }
+
+        var offset = action == "addAbove" ? TimeSpan.FromMilliseconds(-500) : TimeSpan.FromMilliseconds(500);
+        var defaultTimestamp = baseTimestamp.Add(offset);
+
+        var parameters = new Dictionary<string, object?>
+        {
+            [nameof(WeighingInsertDialog.InitialWeight)] = _selectedCell!.Weight,
+            [nameof(WeighingInsertDialog.InitialTimestamp)] = defaultTimestamp,
+            [nameof(WeighingInsertDialog.SelectedDate)] = SelectedDate
+        };
+
+        var title = action == "addAbove" ? "Добавить выше" : "Добавить ниже";
+        var options = new DialogOptions
+        {
+            Width = "420px",
+            CloseDialogOnEsc = true,
+            CloseDialogOnOverlayClick = true
+        };
+
+        var result = await DialogService.OpenAsync<WeighingInsertDialog>(title, parameters, options);
+        return result is WeighingInsertRequest insert ? insert : null;
+    }
+
     async Task OnActionFromGrid(string action)
     {
         if (_selectedCell?.HasValue != true) return;
@@ -432,17 +464,51 @@
 
         var userName = CurrentUser?.Identity?.Name;
 
+        var shouldReload = false;
+
         switch (action)
         {
-            case "inc":      await Data.AdjustAsync(id, +Step, userName); break;
-            case "dec":      await Data.AdjustAsync(id, -Step, userName); break;
-            case "addAbove": await Data.InsertAboveAsync(id, _selectedCell!.Weight ?? 0, userName); break;
-            case "addBelow": await Data.InsertBelowAsync(id, _selectedCell!.Weight ?? 0, userName); break;
-            case "delete":   await Data.DeleteAsync(id, userName); break;
-            case "logs": await SaveReturnTicketAsync(); Nav.NavigateTo("/logs?from=mon"); return;
+            case "inc":
+                await Data.AdjustAsync(id, +Step, userName);
+                shouldReload = true;
+                break;
+            case "dec":
+                await Data.AdjustAsync(id, -Step, userName);
+                shouldReload = true;
+                break;
+            case "addAbove":
+            case "addBelow":
+                var insertRequest = await OpenInsertDialogAsync(action);
+                if (insertRequest is null)
+                {
+                    return;
+                }
+
+                if (action == "addAbove")
+                {
+                    await Data.InsertAboveAsync(id, insertRequest.Weight, insertRequest.Timestamp, userName);
+                }
+                else
+                {
+                    await Data.InsertBelowAsync(id, insertRequest.Weight, insertRequest.Timestamp, userName);
+                }
+
+                shouldReload = true;
+                break;
+            case "delete":
+                await Data.DeleteAsync(id, userName);
+                shouldReload = true;
+                break;
+            case "logs":
+                await SaveReturnTicketAsync();
+                Nav.NavigateTo("/logs?from=mon");
+                return;
         }
 
-        await LoadPage(_pageIndex);
+        if (shouldReload)
+        {
+            await LoadPage(_pageIndex);
+        }
     }
 
     Task OnActionFromDetails(string action) => OnActionFromGrid(action);

--- a/Scalemon.WebApp/Data/IWeighingDataService.cs
+++ b/Scalemon.WebApp/Data/IWeighingDataService.cs
@@ -1,3 +1,4 @@
+using System;
 using Scalemon.WebApp.Models;
 using static Scalemon.WebApp.Models.WeighingModels;
 
@@ -17,8 +18,12 @@ namespace Scalemon.WebApp.Data
         Task AdjustAsync(int id, decimal delta, string? userName, CancellationToken ct = default);
         Task<int> InsertAboveAsync(int refId, decimal weight, CancellationToken ct = default);
         Task<int> InsertAboveAsync(int refId, decimal weight, string? userName, CancellationToken ct = default);
+        Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default);
+        Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default);
         Task<int> InsertBelowAsync(int refId, decimal weight, CancellationToken ct = default);
         Task<int> InsertBelowAsync(int refId, decimal weight, string? userName, CancellationToken ct = default);
+        Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default);
+        Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default);
         Task DeleteAsync(int id, CancellationToken ct = default);
         Task DeleteAsync(int id, string? userName, CancellationToken ct = default);
 

--- a/Scalemon.WebApp/Data/SqlWeighingDataService.cs
+++ b/Scalemon.WebApp/Data/SqlWeighingDataService.cs
@@ -255,15 +255,27 @@ OFFSET @skip ROWS FETCH NEXT @take ROWS ONLY;";
         => InsertAboveAsync(refId, weight, null, ct);
 
     public Task<int> InsertAboveAsync(int refId, decimal weight, string? userName, CancellationToken ct = default)
-        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName, ct);
+        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName, null, ct);
+
+    public Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default)
+        => InsertAboveAsync(refId, weight, timestamp, null, ct);
+
+    public Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default)
+        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName, timestamp, ct);
 
     public Task<int> InsertBelowAsync(int refId, decimal weight, CancellationToken ct = default)
         => InsertBelowAsync(refId, weight, null, ct);
 
     public Task<int> InsertBelowAsync(int refId, decimal weight, string? userName, CancellationToken ct = default)
-        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName, ct);
+        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName, null, ct);
 
-    private async Task<int> InsertNearAsync(int refId, decimal weight, TimeSpan offset, string? userName, CancellationToken ct)
+    public Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default)
+        => InsertBelowAsync(refId, weight, timestamp, null, ct);
+
+    public Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default)
+        => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName, timestamp, ct);
+
+    private async Task<int> InsertNearAsync(int refId, decimal weight, TimeSpan offset, string? userName, DateTime? explicitTimestamp, CancellationToken ct)
     {
         await EnsureConfiguredAsync(ct);
 
@@ -288,7 +300,7 @@ OFFSET @skip ROWS FETCH NEXT @take ROWS ONLY;";
                 return 0;
             }
 
-            var ts = baseTs.Value + offset;
+            var ts = explicitTimestamp ?? baseTs.Value + offset;
             var roundedWeight = Round2(weight);
 
             var insSql = $@"

--- a/Scalemon.WebApp/Data/WeighingDataService.cs
+++ b/Scalemon.WebApp/Data/WeighingDataService.cs
@@ -89,13 +89,25 @@ namespace Scalemon.WebApp.Data
             => InsertAboveAsync(refId, weight, null, ct);
 
         public Task<int> InsertAboveAsync(int refId, decimal weight, string? userName, CancellationToken ct = default)
-            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName);
+            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName, null);
+
+        public Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default)
+            => InsertAboveAsync(refId, weight, timestamp, null, ct);
+
+        public Task<int> InsertAboveAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default)
+            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(-500), userName, timestamp);
 
         public Task<int> InsertBelowAsync(int refId, decimal weight, CancellationToken ct = default)
             => InsertBelowAsync(refId, weight, null, ct);
 
         public Task<int> InsertBelowAsync(int refId, decimal weight, string? userName, CancellationToken ct = default)
-            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName);
+            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName, null);
+
+        public Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, CancellationToken ct = default)
+            => InsertBelowAsync(refId, weight, timestamp, null, ct);
+
+        public Task<int> InsertBelowAsync(int refId, decimal weight, DateTime timestamp, string? userName, CancellationToken ct = default)
+            => InsertNearAsync(refId, weight, TimeSpan.FromMilliseconds(500), userName, timestamp);
 
         public Task DeleteAsync(int id, CancellationToken ct = default)
             => DeleteAsync(id, null, ct);
@@ -125,7 +137,7 @@ namespace Scalemon.WebApp.Data
             return Task.CompletedTask;
         }
 
-        private Task<int> InsertNearAsync(int refId, decimal weight, TimeSpan offset, string? userName)
+        private Task<int> InsertNearAsync(int refId, decimal weight, TimeSpan offset, string? userName, DateTime? explicitTimestamp)
         {
             int newId = 0;
             lock (_sync)
@@ -137,7 +149,7 @@ namespace Scalemon.WebApp.Data
                 }
 
                 var refItem = _data[day][idx];
-                var ts = refItem.Timestamp.Add(offset);
+                var ts = explicitTimestamp ?? refItem.Timestamp.Add(offset);
 
                 newId = _nextId++;
                 var rounded = Round2(weight);

--- a/Scalemon.WebApp/Models/WeighingModels.cs
+++ b/Scalemon.WebApp/Models/WeighingModels.cs
@@ -17,5 +17,7 @@
         public sealed record GridRowVm(int No, GridRow Row);
 
         public sealed record DaySummary(int Count, decimal Sum, decimal? Min, decimal? Max, decimal? Avg);
+
+        public sealed record WeighingInsertRequest(decimal Weight, DateTime Timestamp);
     }
 }


### PR DESCRIPTION
## Summary
- add a Radzen dialog that captures weight and timestamp before inserting a new weighing entry above or below the selected record
- extend the weighing data services with overloads that accept explicit timestamps and reuse them from the monitoring page
- ensure the dialog parses decimal weights with either commas or dots so users can type values regardless of keyboard layout

## Testing
- dotnet build Scalemon.WebApp/Scalemon.WebApp.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e207a2b0832fbce4eb90d6cd506b