### PR TITLE
fix: ensure insert dialog resets defaults on reopen

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -38,21 +38,33 @@
 
     FormModel Model { get; set; } = new();
 
+    bool _modelInitialized;
+    decimal? _lastInitialWeight;
+    DateTime? _lastInitialTimestamp;
+    DateTime _lastSelectedDate;
+
     protected override void OnParametersSet()
     {
-        Model ??= new FormModel();
+        var shouldReset = !_modelInitialized
+            || !Nullable.Equals(_lastInitialWeight, InitialWeight)
+            || !Nullable.Equals(_lastInitialTimestamp, InitialTimestamp)
+            || _lastSelectedDate != SelectedDate;
 
-        if (string.IsNullOrWhiteSpace(Model.WeightText) && InitialWeight is decimal weight)
+        if (!shouldReset)
         {
-            Model.WeightText = weight.ToString("0.00", CultureInfo.CurrentCulture);
+            return;
         }
 
-        if (Model.Time is null)
+        _modelInitialized = true;
+        _lastInitialWeight = InitialWeight;
+        _lastInitialTimestamp = InitialTimestamp;
+        _lastSelectedDate = SelectedDate;
+
+        Model = new FormModel
         {
-            var baseTimestamp = InitialTimestamp ?? SelectedDate;
-            var normalized = SelectedDate.Date.Add(baseTimestamp.TimeOfDay);
-            Model.Time = normalized;
-        }
+            WeightText = FormatWeight(InitialWeight),
+            Time = NormalizeTimestamp(InitialTimestamp, SelectedDate)
+        };
     }
 
     Task OnValidSubmit(FormModel model)
@@ -122,5 +134,14 @@
     {
         public string? WeightText { get; set; }
         public DateTime? Time { get; set; }
+    }
+
+    static string? FormatWeight(decimal? weight)
+        => weight.HasValue ? weight.Value.ToString("0.00", CultureInfo.CurrentCulture) : null;
+
+    static DateTime NormalizeTimestamp(DateTime? timestamp, DateTime selectedDate)
+    {
+        var baseTimestamp = timestamp ?? selectedDate;
+        return selectedDate.Date.Add(baseTimestamp.TimeOfDay);
     }
 }


### PR DESCRIPTION
## Summary
- track the last parameters passed into `WeighingInsertDialog` and rebuild the form model when they change
- centralize weight formatting and timestamp normalization so the dialog always shows the current defaults

## Testing
- not run (environment lacks .NET SDK)

------
https://chatgpt.com/codex/tasks/task_e_68e8f485b4b0832fbe61952c2550c6bb