### PR TITLE
fix(webapp): ensure dialog time updates

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -14,6 +14,7 @@
             <RadzenFormField Text="Время" HelpText="Укажите точное время фиксации">
                 <RadzenStack Orientation="Orientation.Horizontal" Gap="8px">
                     <RadzenNumeric @bind-Value="Model.Hour"
+                                   @bind-Value:event="input"
                                    TValue="int?"
                                    Name="Hour"
                                    Min="0"
@@ -22,6 +23,7 @@
                                    Style="width:100%"
                                    Placeholder="Часы" />
                     <RadzenNumeric @bind-Value="Model.Minute"
+                                   @bind-Value:event="input"
                                    TValue="int?"
                                    Name="Minute"
                                    Min="0"
@@ -30,6 +32,7 @@
                                    Style="width:100%"
                                    Placeholder="Минуты" />
                     <RadzenNumeric @bind-Value="Model.Second"
+                                   @bind-Value:event="input"
                                    TValue="int?"
                                    Name="Second"
                                    Min="0"


### PR DESCRIPTION
## Summary
- ensure the RadzenNumeric inputs for time in the weighing insert dialog update on every keystroke
- prevent the dialog from losing the entered time when submitting while the field is still focused

## Testing
- not run (per repository instructions)

## Docs
- [Radzen Numeric component](https://blazor.radzen.com/numeric)

------
https://chatgpt.com/codex/tasks/task_e_68e8ff511860832fa62e1c26c301b612