### PR TITLE
fix: preserve global helpers when auth.js reloads

### DIFF
--- a/Scalemon.WebApp/wwwroot/auth.js
+++ b/Scalemon.WebApp/wwwroot/auth.js
@@ -1,5 +1,7 @@
-﻿// wwwroot/auth.js
-window.scalemon = {
+// wwwroot/auth.js
+window.scalemon = window.scalemon || {};
+
+Object.assign(window.scalemon, {
     login: async function (username, password) {
         const r = await fetch('/api/auth/login', {
             method: 'POST',
@@ -16,5 +18,4 @@ window.scalemon = {
         });
         return response.ok;
     }
-};
-
+});


### PR DESCRIPTION
## Summary
- keep the existing `window.scalemon` object when auth.js runs
- merge the authentication helpers into the shared namespace so other scripts keep working after dialogs reopen

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e91168c654832fa95682d67a137433