### PR TITLE
fix(webapp): align weight insert dialog numeric types

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -9,12 +9,12 @@
                 <RadzenNumeric Name="Weight"
                                TValue="decimal?"
                                @bind-Value="Model.Weight"
-                               Min="0.001m" Max="1000m" Step="0.01m"
+                               Min="@(0.001m)" Max="@(1000m)" Step="@(0.01m)"
                                Style="width:100%" />
                 <RadzenRequiredValidator Component="Weight"
                                          Text="Укажите вес" Popup="false" />
                 <RadzenNumericRangeValidator Component="Weight"
-                                             Min="0.001" Max="1000"
+                                             Min="@(0.001m)" Max="@(1000m)"
                                              Text="Вес должен быть в диапазоне 0,001…1000 кг"
                                              Popup="false" />
             </div>


### PR DESCRIPTION
## Summary
- pass decimal values to the Radzen numeric field in WeighingInsertDialog so its min/max/step are treated as numbers instead of strings
- align the validator bounds with decimal values to keep the dialog consistent with the service layer expectations and avoid type mismatches

## Testing
- not run (dotnet SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e9188ec260832fb3413b570f93e800