### PR TITLE
fix(webapp): stabilize weight dialog numeric bounds

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -1,4 +1,3 @@
-@using System.Globalization
 @inject DialogService DialogService
 
 <RadzenTemplateForm TItem="FormModel" Data="@Model" Submit="@OnValidSubmit">
@@ -9,12 +8,12 @@
                 <RadzenNumeric Name="Weight"
                                TValue="decimal?"
                                @bind-Value="Model.Weight"
-                               Min="0.001m" Max="1000m" Step="0.01m"
+                               Min="@WeightMinString" Max="@WeightMaxString" Step="@WeightStepString"
                                Style="width:100%" />
                 <RadzenRequiredValidator Component="Weight"
                                          Text="Укажите вес" Popup="false" />
                 <RadzenNumericRangeValidator Component="Weight"
-                                             Min="0.001" Max="1000"
+                                             Min="@WeightMinString" Max="@WeightMaxString"
                                              Text="Вес должен быть в диапазоне 0,001…1000 кг"
                                              Popup="false" />
             </div>
@@ -113,4 +112,8 @@
         public int? Minute { get; set; }
         public int? Second { get; set; }
     }
+
+    private const string WeightMinString = "0.001";
+    private const string WeightMaxString = "1000";
+    private const string WeightStepString = "0.01";
 }


### PR DESCRIPTION
## Summary
- expose the weight numeric limits via invariant string constants so Radzen receives proper numeric values
- reuse the same constants in the validator to keep its range aligned with the numeric input

## Testing
- not run (dotnet SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e9188ec260832fb3413b570f93e800