### PR TITLE
fix(webapp): enable decimal weight entry in insert dialog

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -7,12 +7,16 @@
                 <RadzenLabel Text="Вес, кг" Component="Weight" />
                 <RadzenNumeric Name="Weight"
                                TValue="decimal?"
-                               @bind-Value="Model.Weight"                               
+                               @bind-Value="Model.Weight"
+                               @bind-Value:format="@WeightFormat"
+                               Min="@WeightMin"
+                               Max="@WeightMax"
+                               Step="@WeightStep"
                                Style="width:100%" />
                 <RadzenRequiredValidator Component="Weight"
                                          Text="Укажите вес" Popup="false" />
                 <RadzenNumericRangeValidator Component="Weight"
-                                             Min="@(0.001m)" Max="@(1000m)"
+                                             Min="@WeightMin" Max="@WeightMax"
                                              Text="Вес должен быть в диапазоне 0,001…1000 кг"
                                              Popup="false" />
             </div>
@@ -101,7 +105,9 @@
         var ts = new DateTime(d.Year, d.Month, d.Day,
                               Model.Hour!.Value, Model.Minute!.Value, Model.Second!.Value);
 
-        DialogService.Close(new Result(Model.Weight!.Value, ts));
+        var weight = Math.Round(Model.Weight!.Value, WeightPrecisionDigits, MidpointRounding.AwayFromZero);
+
+        DialogService.Close(new Result(weight, ts));
     }
 
     public sealed class FormModel
@@ -112,7 +118,9 @@
         public int? Second { get; set; }
     }
 
-    private const string WeightMinString = "0.001";
-    private const string WeightMaxString = "1000";
-    private const string WeightStepString = "0.01";
+    private const decimal WeightMin = 0.001m;
+    private const decimal WeightMax = 1000m;
+    private const decimal WeightStep = 0.001m;
+    private const string WeightFormat = "0.000";
+    private const int WeightPrecisionDigits = 3;
 }


### PR DESCRIPTION
## Summary
- configure the weight editor in the weighing insert dialog to use a decimal step, range and format so that operators can input fractional kilograms
- round the submitted weight to the supported precision before returning it from the dialog to keep database writes consistent

## Testing
- Not run (Codex environment)

## Manual verification
1. `dotnet build Scalemon.WebApp`
2. Launch Scalemon.WebApp with your usual profile and open the weighing insert dialog.
3. Enter a fractional weight and confirm it is saved.

## References
- https://razor.radzen.com/numeric

------
https://chatgpt.com/codex/tasks/task_e_68e91f62a94c832fbfcbd302d5794da9