### PR TITLE
fix: unwrap Radzen dialog result in monitoring page

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -458,6 +458,14 @@
             return new WeighingInsertRequest(r.WeightKg, r.Timestamp);
         }
 
+        if (res is Radzen.DialogResult dialogResult && dialogResult.Result == true)
+        {
+            if (dialogResult.Data is WeighingInsertDialog.Result wrapped)
+            {
+                return new WeighingInsertRequest(wrapped.WeightKg, wrapped.Timestamp);
+            }
+        }
+
         return null;
 
         DateTime ClampToSelectedDay(DateTime value)


### PR DESCRIPTION
## Summary
- ensure the monitoring page unwraps Radzen's DialogResult to always build a WeighingInsertRequest when the insert dialog is confirmed

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e929856944832fbc9738ddefde76c3