### PR TITLE
fix: return insert request directly from dialog

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -1,4 +1,5 @@
 @using System.Globalization
+@using static Scalemon.WebApp.Models.WeighingModels
 
 @inject DialogService DialogService
 
@@ -76,9 +77,6 @@
     [Parameter] public DateTime? BaseDate { get; set; }     // дата строки реестра
     [Parameter] public decimal? InitialWeight { get; set; } // можно null
 
-    // Возвращаемое значение из диалога
-    public sealed record Result(decimal WeightKg, DateTime Timestamp);
-
     // Модель формы НЕ пересоздаём — только меняем свойства
     private readonly FormModel Model = new();
     private bool _initialized;
@@ -109,7 +107,7 @@
 
         var weight = Math.Round(Model.Weight!.Value, WeightPrecisionDigits, MidpointRounding.AwayFromZero);
 
-        DialogService.Close(new Result(weight, ts));
+        DialogService.Close(new WeighingInsertRequest(weight, ts));
     }
 
     public sealed class FormModel

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -453,12 +453,7 @@
 
         var res = await DialogService.OpenAsync<WeighingInsertDialog>(title, parms, opts);
 
-        if (res is WeighingInsertDialog.Result r)
-        {
-            return new WeighingInsertRequest(r.WeightKg, r.Timestamp);
-        }
-
-        return null;
+        return res as WeighingInsertRequest;
 
         DateTime ClampToSelectedDay(DateTime value)
         {


### PR DESCRIPTION
## Summary
- have the insert dialog close with a WeighingInsertRequest so the monitoring page receives a typed payload when the user confirms
- simplify the monitoring page logic to consume the typed request and trigger the insert actions

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e929856944832fbc9738ddefde76c3