### PR TITLE
fix(webapp): submit weighing insert dialog form

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -64,7 +64,10 @@
             </div>
 
             <div class="rz-col-12 rz-flex rz-justify-end rz-gap-2 rz-mt-3">
-                <RadzenButton ButtonStyle="ButtonStyle.Primary" Icon="check" Text="ОК" Submit="true" />
+                <RadzenButton ButtonStyle="ButtonStyle.Primary"
+                              Icon="check"
+                              Text="ОК"
+                              ButtonType="ButtonType.Submit" />
                 <RadzenButton ButtonStyle="ButtonStyle.Light" Icon="close" Text="Отмена"
                               Click="@(_ => DialogService.Close(null))" />
             </div>


### PR DESCRIPTION
## Summary
- ensure the OK button in `WeighingInsertDialog` submits the Radzen template form so the insert request is returned to `Monitoring.razor`

## Testing
- not run (container lacks .NET SDK)

## How to run locally (.NET 8 required)
- `dotnet build Scalemon.sln`
- run the WebApp via `dotnet run --project Scalemon.WebApp` to verify the dialog inserts rows correctly


------
https://chatgpt.com/codex/tasks/task_e_68e933939760832fa3912dcdb6c7084c