### PR TITLE
refactor(webapp): rebuild weighing dialog with radzen components

### DIFF
--- a/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
+++ b/Scalemon.WebApp/Components/Dialogs/WeighingInsertDialog.razor
@@ -5,78 +5,90 @@
 
 <RadzenTemplateForm TItem="FormModel" Data="@Model" Submit="@OnValidSubmit">
     <ChildContent>
-        <div class="rz-p-4 rz-flex rz-flex-column rz-gap-3" style="min-width:520px">
-            <div class="rz-flex rz-gap-3 rz-align-end">
-                <div class="rz-flex rz-flex-column rz-gap-1" style="min-width:180px">
+        <RadzenStack Orientation="Orientation.Vertical" class="rz-p-4" Gap="1.5rem">
+            <RadzenStack Orientation="Orientation.Horizontal"
+                         AlignItems="AlignItems.End"
+                         Gap="1.5rem"
+                         Wrap="FlexWrap.NoWrap">
+                <RadzenStack Orientation="Orientation.Vertical"
+                             Gap="0.5rem">
                     <RadzenLabel Text="Вес, кг" Component="Weight" />
                     <RadzenNumeric Name="Weight"
                                    TValue="decimal?"
                                    @bind-Value="Model.Weight"
                                    Culture="@CultureInfo.CurrentCulture"
-                                   Min=@((decimal)0.02)
-                                   Max=@((decimal)100)
-                                   Step="0.01"
-                                   Style="width:100%" />
+                                   Min=@(double)WeightMin
+                                   Max=@(double)WeightMax
+                                   Step=@(double)WeightStep
+                                   class="rz-w-100" />
                     <RadzenRequiredValidator Component="Weight"
                                              Text="Укажите вес" Popup="false" />
                     <RadzenNumericRangeValidator Component="Weight"
-                                                 Min="0.02" Max="100"
+                                                 Min="@WeightMinText" Max="@WeightMaxText"
                                                  Text="Вес должен быть в диапазоне 0,02…100 кг"
                                                  Popup="false" />
-                </div>
+                </RadzenStack>
 
-                <div class="rz-flex rz-gap-2 rz-align-end">
-                    <div class="rz-flex rz-flex-column rz-gap-1" style="min-width:90px">
-                        <div class="rz-flex rz-align-center">
+                <RadzenStack Orientation="Orientation.Horizontal"
+                             AlignItems="AlignItems.End"
+                             Gap="1rem"
+                             Wrap="FlexWrap.NoWrap">
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
                             <RadzenNumeric Name="Hour"
                                            TValue="int?"
                                            @bind-Value="Model.Hour"
-                                           Min="0" Max="23" Style="width:100%" />
-                            <RadzenLabel Text="ч" Component="Hour" Class="rz-ml-2" />
-                        </div>
+                                           Min="0" Max="23"
+                                           class="rz-w-100" />
+                            <RadzenLabel Text="ч" Component="Hour" />
+                        </RadzenStack>
                         <RadzenRequiredValidator Component="Hour"
                                                  Text="Укажите часы" Popup="false" />
                         <RadzenNumericRangeValidator Component="Hour"
                                                      Min="0" Max="23" Text="0…23" Popup="false" />
-                    </div>
-                    <div class="rz-flex rz-flex-column rz-gap-1" style="min-width:90px">
-                        <div class="rz-flex rz-align-center">
+                    </RadzenStack>
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
                             <RadzenNumeric Name="Minute"
                                            TValue="int?"
                                            @bind-Value="Model.Minute"
-                                           Min="0" Max="59" Style="width:100%" />
-                            <RadzenLabel Text="м" Component="Minute" Class="rz-ml-2" />
-                        </div>
+                                           Min="0" Max="59"
+                                           class="rz-w-100" />
+                            <RadzenLabel Text="м" Component="Minute" />
+                        </RadzenStack>
                         <RadzenRequiredValidator Component="Minute"
                                                  Text="Укажите минуты" Popup="false" />
                         <RadzenNumericRangeValidator Component="Minute"
                                                      Min="0" Max="59" Text="0…59" Popup="false" />
-                    </div>
-                    <div class="rz-flex rz-flex-column rz-gap-1" style="min-width:90px">
-                        <div class="rz-flex rz-align-center">
+                    </RadzenStack>
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0.5rem">
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
                             <RadzenNumeric Name="Second"
                                            TValue="int?"
                                            @bind-Value="Model.Second"
-                                           Min="0" Max="59" Style="width:100%" />
-                            <RadzenLabel Text="с" Component="Second" Class="rz-ml-2" />
-                        </div>
+                                           Min="0" Max="59"
+                                           class="rz-w-100" />
+                            <RadzenLabel Text="с" Component="Second" />
+                        </RadzenStack>
                         <RadzenRequiredValidator Component="Second"
                                                  Text="Укажите секунды" Popup="false" />
                         <RadzenNumericRangeValidator Component="Second"
                                                      Min="0" Max="59" Text="0…59" Popup="false" />
-                    </div>
-                </div>
-            </div>
+                    </RadzenStack>
+                </RadzenStack>
+            </RadzenStack>
 
-            <div class="rz-flex rz-justify-end rz-gap-2 rz-mt-3">
+            <RadzenStack Orientation="Orientation.Horizontal"
+                         JustifyContent="JustifyContent.End"
+                         Gap="0.75rem">
                 <RadzenButton ButtonStyle="ButtonStyle.Primary"
                               Icon="check"
                               Text="ОК"
                               ButtonType="ButtonType.Submit" />
                 <RadzenButton ButtonStyle="ButtonStyle.Light" Icon="close" Text="Отмена"
                               Click="@(_ => DialogService.Close(null))" />
-            </div>
-        </div>
+            </RadzenStack>
+        </RadzenStack>
     </ChildContent>
 </RadzenTemplateForm>
 
@@ -128,10 +140,8 @@
 
     private const decimal WeightMin = 0.02m;
     private const decimal WeightMax = 100m;
-    private const decimal WeightStep = 0.02m;
+    private const decimal WeightStep = 0.01m;
     private static readonly string WeightMinText = WeightMin.ToString(CultureInfo.InvariantCulture);
     private static readonly string WeightMaxText = WeightMax.ToString(CultureInfo.InvariantCulture);
-    private static readonly string WeightStepText = WeightStep.ToString(CultureInfo.InvariantCulture);
-    private const string WeightFormat = "0.00";
     private const int WeightPrecisionDigits = 2;
 }


### PR DESCRIPTION
## Summary
- replace the weighing insert dialog layout with nested RadzenStack containers instead of `<div>` wrappers
- keep the weight and time inputs aligned on a single row using Radzen layout parameters without custom CSS
- reuse the existing validation and numeric settings through shared constants

## Testing
- not run (not available in this environment)

## References
- https://www.radzen.com/blazor/components/stack

------
https://chatgpt.com/codex/tasks/task_e_68e967c90f60832f8547f43692da986b