### PR TITLE
fix: resolve statistics tooltip compilation error

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Statistics.razor
+++ b/Scalemon.WebApp/Components/Pages/Statistics.razor
@@ -52,9 +52,16 @@
                         <RadzenCategoryAxis LabelsRotation="45" />
                         <RadzenValueAxis LabelFormatString="{0}" Min="0" />
                         <RadzenColumnSeries Data="@_chartData"
-                                             CategoryProperty="Interval"
+                                             CategoryProperty="AxisLabel"
                                              ValueProperty="Count"
-                                             Title="Количество взвешиваний" />
+                                             Title="Количество взвешиваний">
+                            <TooltipTemplate Context="point">
+                                @if (point.Data is WeighingRatePoint dataPoint)
+                                {
+                                    <div>@dataPoint.TooltipLabel: @point.Value</div>
+                                }
+                            </TooltipTemplate>
+                        </RadzenColumnSeries>
                     </RadzenChart>
                 }
             </RadzenColumn>
@@ -103,7 +110,7 @@
     private string? _calendarError;
     private int _totalWeighings;
 
-    private sealed record WeighingRatePoint(string Interval, int Count);
+    private sealed record WeighingRatePoint(string Interval, int Count, string AxisLabel, string TooltipLabel);
 
     protected override async Task OnInitializedAsync()
     {
@@ -202,7 +209,12 @@
         for (var i = 0; i < IntervalCount; i++)
         {
             var start = ChartStart + TimeSpan.FromMinutes(IntervalMinutes * i);
-            items.Add(new WeighingRatePoint(FormatIntervalLabel(start), 0));
+            var intervalLabel = FormatIntervalLabel(start);
+            items.Add(new WeighingRatePoint(
+                Interval: intervalLabel,
+                Count: 0,
+                AxisLabel: CreateAxisLabel(intervalLabel, i),
+                TooltipLabel: intervalLabel));
         }
 
         return items;
@@ -232,11 +244,19 @@
         for (var i = 0; i < IntervalCount; i++)
         {
             var start = ChartStart + TimeSpan.FromMinutes(IntervalMinutes * i);
-            items.Add(new WeighingRatePoint(FormatIntervalLabel(start), buckets[i]));
+            var intervalLabel = FormatIntervalLabel(start);
+            items.Add(new WeighingRatePoint(
+                Interval: intervalLabel,
+                Count: buckets[i],
+                AxisLabel: CreateAxisLabel(intervalLabel, i),
+                TooltipLabel: intervalLabel));
         }
 
         return items;
     }
+
+    private static string CreateAxisLabel(string intervalLabel, int index)
+        => index % 4 == 0 ? intervalLabel : new string('\u200B', index + 1);
 
     private static string FormatIntervalLabel(TimeSpan start)
     {


### PR DESCRIPTION
## Summary
- extend the statistics chart data model with dedicated axis and tooltip labels while keeping aggregation logic on Count
- generate axis labels every fourth interval and use zero-width placeholders for hidden categories
- fix the column series tooltip template to display the original interval without compile errors

## Testing
- not run (CI only)

## How to run locally
- dotnet restore
- dotnet run --project Scalemon.WebApp


------
https://chatgpt.com/codex/tasks/task_e_68e97ebf53a0832f97c20b425473dbf5