### PR TITLE
feat: enable csv export download

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Logs.razor
+++ b/Scalemon.WebApp/Components/Pages/Logs.razor
@@ -48,7 +48,7 @@
 
   <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem">
     <RadzenButton Icon="refresh" Text="Обновить" Click="@ReloadAsync" ButtonStyle="ButtonStyle.Primary" />
-    <RadzenButton Icon="download" Text="Экспорт CSV" Click="@DownloadCsv" />
+    <RadzenButton Icon="download" Text="Экспорт CSV" Click="@DownloadCsvAsync" />
     <RadzenButton Icon="upload" Text="Импорт логов" Click="@TriggerImportDialogAsync" />
   </RadzenStack>
 </RadzenStack>
@@ -231,15 +231,29 @@
 
     private void OnRowSelect(ApiLogEntry entry) => selected = entry;
 
-    private void DownloadCsv()
+    private async Task DownloadCsvAsync()
     {
-        NotificationService.Notify(new NotificationMessage
+        try
         {
-            Severity = NotificationSeverity.Info,
-            Summary = "Экспорт CSV",
-            Detail = "Реализуйте endpoint /api/logs/export для скачивания файла.",
-            Duration = 4000
-        });
+            var bytes = await Api.ExportLogsCsvAsync(path, _cts.Token);
+            if (bytes is null || bytes.Length == 0)
+            {
+                NotificationService.Notify(NotificationSeverity.Info, "Экспорт CSV", "Получен пустой файл логов.");
+                return;
+            }
+
+            var fileName = $"logs-{DateTime.Now:yyyyMMdd-HHmmss}.csv";
+            var base64 = System.Convert.ToBase64String(bytes);
+            await JS.InvokeVoidAsync("scalemon.downloadFile", fileName, "text/csv", base64);
+        }
+        catch (OperationCanceledException)
+        {
+            // загрузка отменена пользователем — ничего не делаем
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Экспорт CSV", ex.Message);
+        }
     }
 
     private async Task TriggerImportDialogAsync()

--- a/Scalemon.WebApp/wwwroot/App.js
+++ b/Scalemon.WebApp/wwwroot/App.js
@@ -82,6 +82,22 @@
                 element.value = "";
             }
         },
+        downloadFile(fileName, contentType, base64Data) {
+            try {
+                const link = document.createElement('a');
+                link.style.display = 'none';
+                link.download = fileName || 'download';
+
+                const dataUrl = `data:${contentType || 'application/octet-stream'};base64,${base64Data}`;
+                link.href = dataUrl;
+
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            } catch (e) {
+                console.error('downloadFile error', e);
+            }
+        },
         localTodayIso: function () {
             var d = new Date();
             var y = d.getFullYear();


### PR DESCRIPTION
## Summary
- replace the CSV export placeholder on Logs.razor with a real download that calls the api/logs/export endpoint
- add a JavaScript helper to trigger saving the received CSV file in the browser

## Testing
- not run (execution not available in this environment)

## Local run
- dotnet build Scalemon.WebApp

------
https://chatgpt.com/codex/tasks/task_e_68fdd2d82360832fa4a235bd24113952