### PR TITLE
feat(webapp): add monitoring summary rows

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -67,6 +67,7 @@
         <WeightsGrid @ref="_grid"
                      IsDetailed="@_isDetailed"
                      Rows="@_rows"
+                     SummaryRows="@_summaryRows"
                      Totals="@_totals"
                      TotalCount="@_totalCount"
                      PageSize="400"
@@ -120,6 +121,7 @@
     bool _isDetailed = true;
 
     IReadOnlyList<GridRowVm> _rows = Array.Empty<GridRowVm>();
+    IReadOnlyList<GridRowVm> _summaryRows = Array.Empty<GridRowVm>();
     IReadOnlyDictionary<int, WeighingEditEntry> _latestEdits = new Dictionary<int, WeighingEditEntry>();
     decimal[] _totals = new decimal[10];
     int _totalCount = 0;
@@ -363,10 +365,51 @@
             rows.Add(new GridRowVm(r + 1, data));
         }
         _rows = rows;
+        _summaryRows = BuildSummaryRows(rows);
 
         // итоги по столбцам
         for (int col = 0; col < 10; col++)
             _totals[col] = columns[col].Where(c => c.HasValue).Sum(c => c!.Weight!.Value);
+    }
+
+    static IReadOnlyList<GridRowVm> BuildSummaryRows(IReadOnlyList<GridRowVm> rows)
+    {
+        if (rows.Count == 0)
+            return Array.Empty<GridRowVm>();
+
+        var summary = new List<GridRowVm>();
+
+        summary.Add(rows[0]);
+        summary.Add(CreateEmptySummaryRow());
+
+        if (rows.Count >= 3)
+        {
+            var secondLastIndex = rows.Count - 2;
+            if (secondLastIndex != 0)
+            {
+                summary.Add(rows[secondLastIndex]);
+            }
+        }
+
+        if (rows.Count >= 2)
+        {
+            var lastIndex = rows.Count - 1;
+            if (lastIndex != 0)
+            {
+                summary.Add(rows[lastIndex]);
+            }
+        }
+
+        return summary;
+    }
+
+    static GridRowVm CreateEmptySummaryRow()
+    {
+        static Cell EmptyCell() => new(null, null, null);
+
+        return new GridRowVm(0, new GridRow(
+            EmptyCell(), EmptyCell(), EmptyCell(), EmptyCell(), EmptyCell(),
+            EmptyCell(), EmptyCell(), EmptyCell(), EmptyCell(), EmptyCell()));
     }
 
     Task OnCellSelected(Cell? cell)

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -52,25 +52,40 @@
 }
 else
 {
-    <!-- Сводный режим: только заголовки и последняя строка -->
+    <!-- Сводный режим: сводные строки и итоги -->
     <RadzenDataGrid TItem="GridRowVm"
-                    Data="Array.Empty<GridRowVm>()"
+                    Data="SummaryRows"
                     AllowPaging="false"
                     AllowSorting="false"
                     AllowFiltering="false"
                     EmptyText=""
                     class="weights-grid summary-grid">
         <Columns>
-            <RadzenDataGridColumn TItem="GridRowVm" Title="№" Width="80px" TextAlign="TextAlign.Center">
+            <RadzenDataGridColumn TItem="GridRowVm" Property="No" Title="№" Width="80px" TextAlign="TextAlign.Center">
+                <Template Context="vm">
+                    @if (vm.No > 0)
+                    {
+                        @vm.No
+                    }
+                </Template>
                 <FooterTemplate><span class="totals-caption">ИТОГО:</span></FooterTemplate>
             </RadzenDataGridColumn>
 
             @for (var i = 1; i <= 10; i++)
             {
                 var colIndex = i;
-                <RadzenDataGridColumn TItem="GridRowVm" Title="@($"{colIndex}")" Width="1fr" TextAlign="TextAlign.Center">
+                <RadzenDataGridColumn TItem="GridRowVm" Property="@($"C{colIndex}")" Title="@($"{colIndex}")" Width="1fr" TextAlign="TextAlign.Center">
+                    <Template Context="vm">
+                        @{
+                            var cell = GetCell(vm.Row, colIndex);
+                        }
+                        <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)"
+                             title="@cell?.Timestamp?.ToString("HH:mm:ss")"><b>
+                            @cell?.Weight?.ToString("0.00")</b>
+                        </div>
+                    </Template>
                     <FooterTemplate>
-						<b> @(Totals is { Length: >= 10 } ? Totals![colIndex - 1].ToString("0.00") : "")</b>
+                                                <b> @(Totals is { Length: >= 10 } ? Totals![colIndex - 1].ToString("0.00") : "")</b>
                     </FooterTemplate>
                 </RadzenDataGridColumn>
             }
@@ -85,6 +100,7 @@ else
     [Parameter] public bool IsDetailed { get; set; } = true;
     [Parameter] public decimal[]? Totals { get; set; } // длина 10
     [Parameter] public IReadOnlyList<GridRowVm> Rows { get; set; } = Array.Empty<GridRowVm>();
+    [Parameter] public IReadOnlyList<GridRowVm> SummaryRows { get; set; } = Array.Empty<GridRowVm>();
 
     [Parameter] public int TotalCount { get; set; }
     [Parameter] public int PageSize { get; set; } = 400;


### PR DESCRIPTION
## Summary
- compose summary rows on the monitoring page to reuse in the grid view
- expose the summary rows via a new parameter on WeightsGrid and render them in summary mode with templates identical to the detailed view

## Testing
- not run (not supported in container)

## References
- https://www.radzen.com/documentation/datagrid/


------
https://chatgpt.com/codex/tasks/task_e_68ffa484a170832fab18b7fe48a08fe0