### PR TITLE
feat(webapp): highlight duplicate weights on monitoring page

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -57,6 +57,14 @@
                 
                 
 
+                @if (_isDetailed)
+                {
+                    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                        <RadzenText TextStyle="TextStyle.Subtitle2">Включить/выключить подсветку</RadzenText>
+                        <RadzenSwitch Value="@_highlightDuplicates"
+                                      ValueChanged="@OnHighlightDuplicatesChanged" />
+                    </RadzenStack>
+                }
                 <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
                     <RadzenText TextStyle="TextStyle.Subtitle2">@(_isDetailed ? "Подробный" : "Сводный")</RadzenText>
                     <RadzenSwitch @bind-Value="_isDetailed" @bind-Value:after="OnUiChanged" />
@@ -66,6 +74,7 @@
 
         <WeightsGrid @ref="_grid"
                      IsDetailed="@_isDetailed"
+                     HighlightDuplicates="@_highlightDuplicates"
                      Rows="@_rows"
                      SummaryRows="@_summaryRows"
                      Totals="@_totals"
@@ -119,6 +128,7 @@
     DaySummary? _daySummary;
 
     bool _isDetailed = true;
+    bool _highlightDuplicates;
 
     IReadOnlyList<GridRowVm> _rows = Array.Empty<GridRowVm>();
     IReadOnlyList<GridRowVm> _summaryRows = Array.Empty<GridRowVm>();
@@ -137,6 +147,7 @@
     sealed class MonitoringUiStateV2
     {
         public bool? IsDetailed { get; set; }
+        public bool? HighlightDuplicates { get; set; }
     }
 
     sealed class ReturnToMonitoring
@@ -286,6 +297,11 @@
             {
                 _isDetailed = det;
             }
+
+            if (s?.HighlightDuplicates is bool highlight)
+            {
+                _highlightDuplicates = highlight;
+            }
         }
         catch { /* ok */ }
     }
@@ -293,7 +309,22 @@
     async Task SaveUiStateAsync()
     {
         if (!_uiLoaded) return;
-        await PLS.SetAsync(UiStateKey, new MonitoringUiStateV2 { IsDetailed = _isDetailed });
+        await PLS.SetAsync(UiStateKey, new MonitoringUiStateV2
+        {
+            IsDetailed = _isDetailed,
+            HighlightDuplicates = _highlightDuplicates
+        });
+    }
+
+    async Task OnHighlightDuplicatesChanged(bool value)
+    {
+        if (_highlightDuplicates == value)
+            return;
+
+        _highlightDuplicates = value;
+        await InvokeAsync(StateHasChanged);
+
+        await SaveUiStateAsync();
     }
 
 
@@ -331,6 +362,28 @@
     {
         var ordered = items.OrderBy(x => x.Timestamp).ToList();
 
+        var duplicateIds = new HashSet<int>();
+        int index = 0;
+        while (index < ordered.Count)
+        {
+            var currentWeight = ordered[index].Weight;
+            int runEnd = index + 1;
+            while (runEnd < ordered.Count && ordered[runEnd].Weight == currentWeight)
+            {
+                runEnd++;
+            }
+
+            if (runEnd - index >= 2)
+            {
+                for (int i = index; i < runEnd; i++)
+                {
+                    duplicateIds.Add(ordered[i].Id);
+                }
+            }
+
+            index = runEnd;
+        }
+
         // 10 столбцов по 40 ячеек
         var columns = new List<List<Cell>>(10);
         for (int i = 0; i < 10; i++)
@@ -346,13 +399,18 @@
                 ? edit.Action
                 : (WeighingEditAction?)null;
 
-            columns[col].Add(new Cell(ordered[i].Id, ordered[i].Weight, ordered[i].Timestamp, highlightAction));
+            var cell = new Cell(ordered[i].Id, ordered[i].Weight, ordered[i].Timestamp, highlightAction)
+            {
+                IsDuplicateRun = duplicateIds.Contains(ordered[i].Id)
+            };
+
+            columns[col].Add(cell);
         }
 
         // дополняем пустыми ячейками до 40 в каждом столбце
         for (int col = 0; col < 10; col++)
             while (columns[col].Count < 40)
-                columns[col].Add(new Cell(null, null, null));
+                columns[col].Add(new Cell(null, null, null) { IsDuplicateRun = false });
 
         // собираем строки для грида
         var rows = new List<GridRowVm>(40);

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -108,6 +108,7 @@ else
     [Parameter] public EventCallback<int> PageChanged { get; set; }
     [Parameter] public EventCallback<Cell?> CellSelected { get; set; }
     [Parameter] public EventCallback<string> ActionRequested { get; set; } // inc/dec/addAbove/addBelow/delete/logs
+    [Parameter] public bool HighlightDuplicates { get; set; }
 
     RadzenPager? pager;
 
@@ -263,12 +264,36 @@ else
         return InvokeAsync(StateHasChanged);
     }
 
-    static string GetHighlightClass(Cell? cell) => cell?.LastEditAction switch
+    string GetHighlightClass(Cell? cell)
     {
-        WeighingEditAction.Increment or WeighingEditAction.Decrement => "last-edit-adjust",
-        WeighingEditAction.Insert => "last-edit-insert",
-        _ => string.Empty
-    };
+        if (cell is null)
+        {
+            return string.Empty;
+        }
+
+        List<string>? classes = null;
+
+        switch (cell.LastEditAction)
+        {
+            case WeighingEditAction.Increment:
+            case WeighingEditAction.Decrement:
+                classes ??= new List<string>();
+                classes.Add("last-edit-adjust");
+                break;
+            case WeighingEditAction.Insert:
+                classes ??= new List<string>();
+                classes.Add("last-edit-insert");
+                break;
+        }
+
+        if (HighlightDuplicates && IsDetailed && cell.IsDuplicateRun)
+        {
+            classes ??= new List<string>();
+            classes.Add("duplicate-weight");
+        }
+
+        return classes is null ? string.Empty : string.Join(" ", classes);
+    }
 
     static Cell? GetCell(GridRow row, int col) => col switch
     {

--- a/Scalemon.WebApp/Models/WeighingModels.cs
+++ b/Scalemon.WebApp/Models/WeighingModels.cs
@@ -7,6 +7,8 @@
         public sealed record Cell(int? Id, decimal? Weight, DateTime? Timestamp, WeighingEditAction? LastEditAction = null)
         {
             public bool HasValue => Id.HasValue && Weight.HasValue && Timestamp.HasValue;
+
+            public bool IsDuplicateRun { get; init; } = false;
         }
 
         public sealed record GridRow(Cell C1, Cell C2, Cell C3, Cell C4, Cell C5, Cell C6, Cell C7, Cell C8, Cell C9, Cell C10)

--- a/Scalemon.WebApp/wwwroot/app.css
+++ b/Scalemon.WebApp/wwwroot/app.css
@@ -7,3 +7,8 @@
     background-color: var(--rz-success-lighter);
     color: var(--rz-success-contrast);
 }
+
+.cell.duplicate-weight {
+    background-color: var(--rz-danger-dark);
+    color: var(--rz-danger-contrast);
+}


### PR DESCRIPTION
## Summary
- add a Radzen toggle to control duplicate highlighting on the monitoring grid and persist the preference
- flag duplicate weight runs when building the matrix so grid cells know when to highlight
- update the weights grid and CSS to apply duplicate styling when enabled

## Testing
- not run (container environment)

## References
- [Radzen Switch documentation](https://www.radzen.com/documentation/blazor/switch/)


------
https://chatgpt.com/codex/tasks/task_e_68ffc41f9ec0832f8de55529a1574b3d