### PR TITLE
feat: add highlight toggle for repeated weights

### DIFF
--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -57,15 +57,25 @@
                 
                 
 
-                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
-                    <RadzenText TextStyle="TextStyle.Subtitle2">@(_isDetailed ? "Подробный" : "Сводный")</RadzenText>
-                    <RadzenSwitch @bind-Value="_isDetailed" @bind-Value:after="OnUiChanged" />
+                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="1rem">
+                    @if (_isDetailed)
+                    {
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                            <RadzenText TextStyle="TextStyle.Subtitle2">@(_highlightRepeats ? "Выключить подсветку" : "Включить подсветку")</RadzenText>
+                            <RadzenSwitch @bind-Value="_highlightRepeats" @bind-Value:after="OnHighlightToggleChanged" />
+                        </RadzenStack>
+                    }
+                    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                        <RadzenText TextStyle="TextStyle.Subtitle2">@(_isDetailed ? "Подробный" : "Сводный")</RadzenText>
+                        <RadzenSwitch @bind-Value="_isDetailed" @bind-Value:after="OnUiChanged" />
+                    </RadzenStack>
                 </RadzenStack>
             </RadzenStack>
         </RadzenCard>
 
         <WeightsGrid @ref="_grid"
                      IsDetailed="@_isDetailed"
+                     HighlightSameWeightCells="@(_isDetailed && _highlightRepeats)"
                      Rows="@_rows"
                      SummaryRows="@_summaryRows"
                      Totals="@_totals"
@@ -119,6 +129,7 @@
     DaySummary? _daySummary;
 
     bool _isDetailed = true;
+    bool _highlightRepeats;
 
     IReadOnlyList<GridRowVm> _rows = Array.Empty<GridRowVm>();
     IReadOnlyList<GridRowVm> _summaryRows = Array.Empty<GridRowVm>();
@@ -137,6 +148,7 @@
     sealed class MonitoringUiStateV2
     {
         public bool? IsDetailed { get; set; }
+        public bool? HighlightRepeats { get; set; }
     }
 
     sealed class ReturnToMonitoring
@@ -286,6 +298,10 @@
             {
                 _isDetailed = det;
             }
+            if (s?.HighlightRepeats is bool highlight)
+            {
+                _highlightRepeats = highlight;
+            }
         }
         catch { /* ok */ }
     }
@@ -293,7 +309,11 @@
     async Task SaveUiStateAsync()
     {
         if (!_uiLoaded) return;
-        await PLS.SetAsync(UiStateKey, new MonitoringUiStateV2 { IsDetailed = _isDetailed });
+        await PLS.SetAsync(UiStateKey, new MonitoringUiStateV2
+        {
+            IsDetailed = _isDetailed,
+            HighlightRepeats = _highlightRepeats
+        });
     }
 
 
@@ -423,6 +443,7 @@
     }
 
     async Task OnUiChanged() => await SaveUiStateAsync();
+    async Task OnHighlightToggleChanged() => await SaveUiStateAsync();
 
     
     async Task SaveReturnTicketAsync()

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -1,5 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
 @using System.Collections.Generic
+@using System.Linq
 @inject NavigationManager Nav
 @inject ContextMenuService ContextMenu
 @inject NotificationService NotificationService
@@ -36,6 +37,7 @@
                             var cell = GetCell(vm.Row, colIndex); // vm.Row — это GridRow
                         }
                         <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)"
+                             style="@GetDuplicateStyle(vm.No, colIndex)"
                              title="@cell?.Timestamp?.ToString("HH:mm:ss")"><b>
                             @cell?.Weight?.ToString("0.00")</b>
                         </div>
@@ -80,6 +82,7 @@ else
                             var cell = GetCell(vm.Row, colIndex);
                         }
                         <div class="cell @(cell?.HasValue == true ? "has" : "empty") @GetHighlightClass(cell)"
+                             style="@GetDuplicateStyle(vm.No, colIndex)"
                              title="@cell?.Timestamp?.ToString("HH:mm:ss")"><b>
                             @cell?.Weight?.ToString("0.00")</b>
                         </div>
@@ -98,6 +101,7 @@ else
 
 @code {
     [Parameter] public bool IsDetailed { get; set; } = true;
+    [Parameter] public bool HighlightSameWeightCells { get; set; }
     [Parameter] public decimal[]? Totals { get; set; } // длина 10
     [Parameter] public IReadOnlyList<GridRowVm> Rows { get; set; } = Array.Empty<GridRowVm>();
     [Parameter] public IReadOnlyList<GridRowVm> SummaryRows { get; set; } = Array.Empty<GridRowVm>();
@@ -115,6 +119,20 @@ else
     private (int Row, int Col)? _selectedCellPos;
 
     DotNetObjectReference<WeightsGrid>? _dotRef;
+    readonly HashSet<(int Row, int Col)> _duplicateWeightCells = new();
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        if (IsDetailed)
+        {
+            UpdateDuplicateWeightCells();
+        }
+        else
+        {
+            _duplicateWeightCells.Clear();
+        }
+    }
 
     public int? GetSelectedOrderOnPage()
         => _selectedCellPos is { } pos ? ((pos.Col - 1) * 40 + pos.Row) : null; // 1..400
@@ -128,6 +146,68 @@ else
     
     static int ParseCol(string? p) =>
     p is { Length: > 1 } && p[0] == 'C' && int.TryParse(p.AsSpan(1), out var n) ? n : -1;
+
+    void UpdateDuplicateWeightCells()
+    {
+        _duplicateWeightCells.Clear();
+
+        if (Rows is null || Rows.Count == 0)
+        {
+            return;
+        }
+
+        var orderedRows = Rows.OrderBy(r => r.No).ToList();
+        var currentSequence = new List<(int Row, int Col, decimal Weight)>();
+        decimal? previousWeight = null;
+
+        foreach (var (row, col, cell) in EnumerateCellsInDisplayOrder(orderedRows))
+        {
+            if (cell is null || !cell.HasValue || cell.Weight is not decimal weight)
+            {
+                CommitSequence();
+                currentSequence.Clear();
+                previousWeight = null;
+                continue;
+            }
+
+            if (previousWeight.HasValue && weight == previousWeight.Value)
+            {
+                currentSequence.Add((row, col, weight));
+            }
+            else
+            {
+                CommitSequence();
+                currentSequence.Clear();
+                currentSequence.Add((row, col, weight));
+            }
+
+            previousWeight = weight;
+        }
+
+        CommitSequence();
+
+        void CommitSequence()
+        {
+            if (currentSequence.Count >= 2)
+            {
+                foreach (var (row, col, _) in currentSequence)
+                {
+                    _duplicateWeightCells.Add((row, col));
+                }
+            }
+        }
+    }
+
+    static IEnumerable<(int Row, int Col, Cell? Cell)> EnumerateCellsInDisplayOrder(IList<GridRowVm> rows)
+    {
+        for (int col = 1; col <= 10; col++)
+        {
+            foreach (var vm in rows)
+            {
+                yield return (vm.No, col, GetCell(vm.Row, col));
+            }
+        }
+    }
 
     async Task OnPagerChanged(PagerEventArgs args)
     {
@@ -269,6 +349,11 @@ else
         WeighingEditAction.Insert => "last-edit-insert",
         _ => string.Empty
     };
+
+    string? GetDuplicateStyle(int row, int col)
+        => HighlightSameWeightCells && IsDetailed && _duplicateWeightCells.Contains((row, col))
+            ? "background-color: var(--rz-danger-dark);"
+            : null;
 
     static Cell? GetCell(GridRow row, int col) => col switch
     {


### PR DESCRIPTION
## Summary
- add a RadzenSwitch toggle in the monitoring page to control repeated-weight highlighting using the Radzen Switch component (https://www.radzen.com/documentation/switch/)
- detect consecutive identical weights inside the detailed grid and apply or remove the highlight style based on the toggle state

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ffd979b7a0832fa2fa4a999f06f14d