### PR TITLE
fix: improve Monitoring responsive layout

### DIFF
--- a/Scalemon.WebApp/Components/CalendarWithMarks.razor
+++ b/Scalemon.WebApp/Components/CalendarWithMarks.razor
@@ -1,6 +1,6 @@
 ﻿@using System.Globalization
 
-<RadzenCard class="rz-p-4 rz-w-100">
+<RadzenCard class="rz-p-4 rz-w-100 monitoring-calendar-card">
         <div class="rz-text-align-center">
             <RadzenDatePicker @bind-Value="SelectedDate"
                               TValue="DateTime"

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor
@@ -14,22 +14,22 @@
 @inject ISettingsSource SettingsSource
 @inject DialogService DialogService
 
-<RadzenRow>   
+<RadzenRow class="monitoring-layout">
 
     <!-- ЛЕВАЯ КОЛОНКА: заголовок + таблица -->
-    <RadzenColumn Size="12" SizeLG="9">
+    <RadzenColumn Size="12" SizeMD="12" SizeLG="8" SizeXL="9" class="monitoring-main-column">
         <!-- Новый заголовок с «сводкой» + переключатель режима -->
         <RadzenCard Style="padding:0">
             <RadzenStack Orientation="Orientation.Horizontal"
                          JustifyContent="JustifyContent.SpaceBetween"
                          AlignItems="AlignItems.Center"
-                         class="rz-p-3 rz-pb-2">
+                         class="rz-p-3 rz-pb-2 monitoring-header">
 
-                <RadzenStack Orientation="Orientation.Vertical" class="rz-w-75 rz-pl-4">
-					<RadzenText TextStyle="TextStyle.H5" TextAlign="TextAlign.Left">
-						@(
-												_totalCount > 0
-												? $"Реестр взвешиваний за {SelectedDate:dd.MM.yyyy}"
+                <RadzenStack Orientation="Orientation.Vertical" class="monitoring-header-summary">
+                                        <RadzenText TextStyle="TextStyle.H5" TextAlign="TextAlign.Left">
+                                                @(
+                                                                                                _totalCount > 0
+                                                                                                ? $"Реестр взвешиваний за {SelectedDate:dd.MM.yyyy}"
 												: "Данные за день отсутствуют"
 												)
 					</RadzenText>
@@ -87,29 +87,33 @@
     </RadzenColumn>
 
     <!-- ПРАВАЯ КОЛОНКА: календарь + детали -->
-    <RadzenColumn Size="12" SizeLG="3"
-                  Style="display:flex; flex-direction:column; min-height:100vh;">
+    <RadzenColumn Size="12" SizeMD="12" SizeLG="4" SizeXL="3"
+                  class="monitoring-side-column">
         <!-- Нижний блок, "прилипший" к низу окна -->
-        <div style="margin-top:auto; position:sticky; bottom:0px; z-index:10; width:100%;">
+        <div class="monitoring-side-sticky">
             <RadzenStack Orientation="Orientation.Vertical"
                          AlignItems="AlignItems.Center"
                          Gap="0.75rem"
-                         Style="width:100%; max-height:calc(100vh - 24px); overflow:auto;">
+                         class="monitoring-side-stack">
                 @if (_showDetails && _selectedCell?.HasValue == true)
                 {
-                    <RecordDetailsPanel Cell="@_selectedCell"
+                    <div class="monitoring-panel-wrapper">
+                        <RecordDetailsPanel Cell="@_selectedCell"
                                         OrderInDay="@_selectedOrderInDay"
                                         Visible="@_showDetails"
                                         ActionRequested="@OnActionFromDetails" />
+                    </div>
                 }
-                <div style="min-height:calc(100vh - 700px);">
+                <div class="monitoring-side-spacer">
 
                 </div>
 
-                <CalendarWithMarks SelectedDate="@SelectedDate"
+                <div class="monitoring-calendar-wrapper">
+                    <CalendarWithMarks SelectedDate="@SelectedDate"
                                    SelectedDateChanged="@OnDatePicked"
                                    MarkedDays="@_markedDays"
                                    MonthChanged="@OnMonthChanged" />
+                </div>
             </RadzenStack>
         </div>
     </RadzenColumn>

--- a/Scalemon.WebApp/Components/Pages/Monitoring.razor.css
+++ b/Scalemon.WebApp/Components/Pages/Monitoring.razor.css
@@ -1,1 +1,161 @@
-﻿
+.monitoring-layout {
+    gap: 1rem;
+}
+
+.monitoring-main-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.monitoring-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.monitoring-header-summary {
+    flex: 1 1 420px;
+    padding-left: 1rem;
+}
+
+.monitoring-side-column {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.monitoring-side-sticky {
+    margin-top: auto;
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    z-index: 10;
+}
+
+.monitoring-side-stack {
+    width: 100%;
+    max-height: calc(100vh - 24px);
+    overflow: auto;
+}
+
+.monitoring-panel-wrapper,
+.monitoring-calendar-wrapper {
+    width: 100%;
+}
+
+.monitoring-side-spacer {
+    min-height: calc(100vh - 700px);
+}
+
+:deep(.monitoring-grid .rz-data-grid-header-cell),
+:deep(.monitoring-grid .rz-cell-data) {
+    font-size: 0.95rem;
+    padding: 0.5rem;
+}
+
+:deep(.monitoring-grid .cell) {
+    padding: 6px 8px;
+    height: 28px;
+}
+
+:deep(.monitoring-grid-pager) {
+    margin-top: 0.5rem;
+}
+
+:deep(.monitoring-panel-card) {
+    width: 100%;
+}
+
+:deep(.monitoring-panel-stack) {
+    gap: 0.5rem;
+}
+
+:deep(.monitoring-calendar-card .rz-calendar) {
+    font-size: 0.95rem;
+}
+
+@media (max-width: 1400px) {
+    :deep(.monitoring-grid .rz-data-grid-header-cell),
+    :deep(.monitoring-grid .rz-cell-data) {
+        font-size: 0.9rem;
+        padding: 0.45rem;
+    }
+
+    :deep(.monitoring-grid .cell) {
+        padding: 4px 6px;
+        height: 26px;
+    }
+
+    :deep(.monitoring-calendar-card .rz-calendar) {
+        font-size: 0.9rem;
+    }
+}
+
+@media (max-width: 1200px) {
+    .monitoring-side-column {
+        min-height: auto;
+    }
+
+    .monitoring-side-sticky {
+        position: static;
+    }
+
+    .monitoring-side-stack {
+        max-height: none;
+    }
+
+    .monitoring-side-spacer {
+        min-height: 0;
+    }
+
+    .monitoring-header-summary {
+        padding-left: 0;
+    }
+}
+
+@media (max-width: 992px) {
+    .monitoring-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .monitoring-header-summary {
+        flex-basis: 100%;
+    }
+
+    :deep(.monitoring-grid .rz-data-grid-header-cell),
+    :deep(.monitoring-grid .rz-cell-data) {
+        font-size: 0.85rem;
+        padding: 0.4rem;
+    }
+
+    :deep(.monitoring-grid .cell) {
+        padding: 3px 5px;
+        height: 24px;
+    }
+
+    :deep(.monitoring-calendar-card .rz-calendar) {
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 768px) {
+    :deep(.monitoring-grid .rz-data-grid-header-cell),
+    :deep(.monitoring-grid .rz-cell-data) {
+        font-size: 0.8rem;
+        padding: 0.35rem;
+    }
+
+    :deep(.monitoring-grid .cell) {
+        padding: 3px 4px;
+        height: 22px;
+    }
+
+    :deep(.monitoring-calendar-card .rz-calendar) {
+        font-size: 0.8rem;
+    }
+
+    :deep(.monitoring-panel-card) {
+        padding: 1rem !important;
+    }
+}

--- a/Scalemon.WebApp/Components/RecordDetailsPanel.razor
+++ b/Scalemon.WebApp/Components/RecordDetailsPanel.razor
@@ -6,8 +6,8 @@
 {
 
 
-    <RadzenCard class="rz-p-4 rz-w-100">
-        <RadzenStack Orientation="Orientation.Vertical" class="rz-p-3 rz-border" Gap="0.5rem" JustifyContent="JustifyContent.Center">
+    <RadzenCard class="rz-p-4 rz-w-100 monitoring-panel-card">
+        <RadzenStack Orientation="Orientation.Vertical" class="rz-p-3 rz-border monitoring-panel-stack" Gap="0.5rem" JustifyContent="JustifyContent.Center">
 			<RadzenText TextStyle="TextStyle.H6" TextAlign="TextAlign.Left">Взвешивание № @OrderInDay</RadzenText>
             <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween" class="rz-pb-2">
 				<RadzenStack Orientation="Orientation.Vertical">

--- a/Scalemon.WebApp/Components/SummaryPanel.razor
+++ b/Scalemon.WebApp/Components/SummaryPanel.razor
@@ -1,6 +1,6 @@
 ﻿@using static Scalemon.WebApp.Models.WeighingModels
 
-<RadzenCard Style="padding:0">
+<RadzenCard Style="padding:0" class="monitoring-panel-card">
     <ChildContent>
         <RadzenStack Orientation="Orientation.Vertical" class="rz-p-3" Gap="0.5rem">
             <RadzenText TextStyle="TextStyle.H5">Сводка по дню</RadzenText>

--- a/Scalemon.WebApp/Components/WeightsGrid.razor
+++ b/Scalemon.WebApp/Components/WeightsGrid.razor
@@ -16,7 +16,8 @@
                     CellClick="@OnCellClick"
                     CellDoubleClick="@OnCellDoubleClick"
                     CellContextMenu="@OnCellContextMenu"
-                    CellRender="@OnCellRender">
+                    CellRender="@OnCellRender"
+                    class="weights-grid detailed-grid monitoring-grid">
         <Columns>
             <RadzenDataGridColumn TItem="GridRowVm"
                                   Title="№"
@@ -61,7 +62,7 @@ else
                     AllowSorting="false"
                     AllowFiltering="false"
                     EmptyText=""
-                    class="weights-grid summary-grid">
+                    class="weights-grid summary-grid monitoring-grid">
         <Columns>
             <RadzenDataGridColumn TItem="GridRowVm" Property="No" Title="№" Width="80px" TextAlign="TextAlign.Center">
                 <Template Context="vm">
@@ -97,7 +98,7 @@ else
 }
 
 <!-- Пейджер под таблицей -->
-<RadzenPager @ref="pager" Count="@TotalCount" PageSize="@PageSize" PageChanged="@OnPagerChanged" AlwaysVisible="true" />
+<RadzenPager @ref="pager" Count="@TotalCount" PageSize="@PageSize" PageChanged="@OnPagerChanged" AlwaysVisible="true" class="monitoring-grid-pager" />
 
 @code {
     [Parameter] public bool IsDetailed { get; set; } = true;


### PR DESCRIPTION
## Summary
- update the Monitoring layout columns to use Radzen responsive breakpoints so the grid and side panel stack sooner on narrow screens
- add responsive CSS rules that shrink the weighing grid, pager, calendar, and detail panels without introducing horizontal scrollbars
- tag shared panels and calendar components with utility classes that can be styled responsively from the Monitoring page

## Testing
- not run (not available in container)

## Docs
- https://blazor.radzen.com/row

------
https://chatgpt.com/codex/tasks/task_e_6900e5217e28832f929021425f2a0781