### PR TITLE
feat(webapp): compact monitoring calendar layout

### DIFF
--- a/Scalemon.WebApp/Components/CalendarWithMarks.razor
+++ b/Scalemon.WebApp/Components/CalendarWithMarks.razor
@@ -1,15 +1,17 @@
 ﻿@using System.Globalization
 
-<RadzenCard class="rz-p-4 rz-w-stretch">
-        <div class="rz-text-align-center">
-            <RadzenDatePicker @bind-Value="SelectedDate"
-                              TValue="DateTime"
-                              Inline="true"
-                              ShowTime="false"
-                              DateRender="@OnDateRender"
-                              CurrentDateChanged="@OnCurrentDateChanged"
-                              Change="@OnDateChanged"/>
-        </div>
+<RadzenCard class="rz-p-4 rz-w-stretch monitoring-calendar-card">
+    <div class="rz-text-align-center">
+        <RadzenDatePicker @bind-Value="SelectedDate"
+                          TValue="DateTime"
+                          Inline="true"
+                          ShowTime="false"
+                          CalendarClass="monitoring-calendar"
+                          PopupClass="monitoring-calendar-panel"
+                          DateRender="@OnDateRender"
+                          CurrentDateChanged="@OnCurrentDateChanged"
+                          Change="@OnDateChanged"/>
+    </div>
 </RadzenCard>
 
 @code {

--- a/Scalemon.WebApp/Components/CalendarWithMarks.razor.css
+++ b/Scalemon.WebApp/Components/CalendarWithMarks.razor.css
@@ -1,1 +1,48 @@
-﻿
+.monitoring-calendar-card {
+    padding: 0.5rem;
+    box-sizing: border-box;
+}
+
+::deep .monitoring-calendar {
+    box-sizing: border-box;
+}
+
+::deep .monitoring-calendar * {
+    box-sizing: border-box;
+}
+
+::deep .monitoring-calendar .rz-calendar {
+    font-size: 0.875rem;
+}
+
+::deep .monitoring-calendar .rz-calendar-header {
+    padding: 0.25rem 0.5rem;
+}
+
+::deep .monitoring-calendar .rz-button-icon-only {
+    width: 1.75rem;
+    height: 1.75rem;
+}
+
+::deep .monitoring-calendar .rz-button-icon-only .rz-icon {
+    font-size: 1rem;
+}
+
+::deep .monitoring-calendar .rz-calendar-title {
+    font-size: 0.9375rem;
+    padding: 0.25rem 0.5rem;
+}
+
+::deep .monitoring-calendar .rz-calendar-table button {
+    width: 2rem;
+    height: 2rem;
+    padding: 0.25rem;
+    font-size: 0.8125rem;
+}
+
+::deep .monitoring-calendar .rz-calendar-monthview button,
+::deep .monitoring-calendar .rz-calendar-yearview button {
+    padding: 0.35rem 0.5rem;
+    font-size: 0.8125rem;
+    width: 100%;
+}

--- a/Scalemon.WebApp/wwwroot/app.css
+++ b/Scalemon.WebApp/wwwroot/app.css
@@ -7,3 +7,14 @@
     background-color: var(--rz-success-lighter);
     color: var(--rz-success-contrast);
 }
+
+.monitoring-calendar-panel .rz-dropdown-item {
+    font-size: 0.8125rem;
+    padding: 0.25rem 0.5rem;
+    box-sizing: border-box;
+}
+
+.monitoring-calendar-panel .rz-picker-panel,
+.monitoring-calendar-panel .rz-dropdown-panel {
+    box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add dedicated CSS classes to the monitoring calendar card and popup
- tighten Radzen calendar spacing via scoped styles for the monitoring calendar component
- adjust global dropdown panel styles for compact calendar overlays

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691043aa159c832f8ccceedbc58e50fe)