### PR TITLE
Handle help file resolution and access errors

### DIFF
--- a/Scalemon.UI/Form1.Designer.vb
+++ b/Scalemon.UI/Form1.Designer.vb
@@ -18,14 +18,49 @@ Partial Class Form1
     Private components As System.ComponentModel.IContainer
 
     'Примечание: следующая процедура является обязательной для конструктора форм Windows Forms
-    'Для ее изменения используйте конструктор форм Windows Form.  
+    'Для ее изменения используйте конструктор форм Windows Form.
     'Не изменяйте ее в редакторе исходного кода.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        components = New System.ComponentModel.Container()
+        Me.btnOpenHelp = New System.Windows.Forms.Button()
+        Me.lblHelpPath = New System.Windows.Forms.Label()
+        Me.SuspendLayout()
+        '
+        'btnOpenHelp
+        '
+        Me.btnOpenHelp.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.btnOpenHelp.Location = New System.Drawing.Point(604, 12)
+        Me.btnOpenHelp.Name = "btnOpenHelp"
+        Me.btnOpenHelp.Size = New System.Drawing.Size(184, 29)
+        Me.btnOpenHelp.TabIndex = 0
+        Me.btnOpenHelp.Text = "Открыть справку"
+        Me.btnOpenHelp.UseVisualStyleBackColor = True
+        '
+        'lblHelpPath
+        '
+        Me.lblHelpPath.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+                    Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.lblHelpPath.AutoEllipsis = True
+        Me.lblHelpPath.Location = New System.Drawing.Point(12, 12)
+        Me.lblHelpPath.Name = "lblHelpPath"
+        Me.lblHelpPath.Size = New System.Drawing.Size(586, 29)
+        Me.lblHelpPath.TabIndex = 1
+        Me.lblHelpPath.Text = "Определение пути справки..."
+        Me.lblHelpPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        '
+        'Form1
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 20.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(800, 450)
+        Me.Controls.Add(Me.lblHelpPath)
+        Me.Controls.Add(Me.btnOpenHelp)
+        Me.Name = "Form1"
         Me.Text = "Form1"
+        Me.ResumeLayout(False)
+
     End Sub
 
+    Friend WithEvents btnOpenHelp As Button
+    Friend WithEvents lblHelpPath As Label
 End Class

--- a/Scalemon.UI/Form1.vb
+++ b/Scalemon.UI/Form1.vb
@@ -1,3 +1,13 @@
 ﻿Public Class Form1
+    Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        lblHelpPath.Text = FormHelp.DescribeHelpLocation()
+    End Sub
 
+    Private Sub btnOpenHelp_Click(sender As Object, e As EventArgs) Handles btnOpenHelp.Click
+        Try
+            FormHelp.ShowHelp(Me)
+        Catch ex As Exception
+            MessageBox.Show(ex.Message, "Ошибка", MessageBoxButtons.OK, MessageBoxIcon.Error)
+        End Try
+    End Sub
 End Class

--- a/Scalemon.UI/FormHelp.vb
+++ b/Scalemon.UI/FormHelp.vb
@@ -1,0 +1,59 @@
+﻿Imports System.IO
+Imports System.Windows.Forms
+
+''' <summary>
+''' Определяет используемый файл справки и безопасно открывает его.
+''' Сначала используется файл из папки программы, затем из %AppData%\OrderCreator.
+''' </summary>
+Public Class FormHelp
+    Private Const HelpFileName As String = "help.chm"
+
+    ''' <summary>
+    ''' Возвращает путь к доступному файлу справки или выбрасывает подробное исключение.
+    ''' </summary>
+    Public Shared Function ResolveHelpPath() As String
+        Dim appFolderHelp = Path.Combine(Application.StartupPath, HelpFileName)
+        Dim roamingHelp = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OrderCreator", HelpFileName)
+
+        If File.Exists(appFolderHelp) Then
+            EnsureReadable(appFolderHelp)
+            Return appFolderHelp
+        End If
+
+        If File.Exists(roamingHelp) Then
+            EnsureReadable(roamingHelp)
+            Return roamingHelp
+        End If
+
+        Throw New FileNotFoundException($"Файл справки {HelpFileName} не найден ни в папке программы, ни в %AppData%\\OrderCreator.")
+    End Function
+
+    ''' <summary>
+    ''' Возвращает описание найденной справки или текст ошибки, если путь определить нельзя.
+    ''' </summary>
+    Public Shared Function DescribeHelpLocation() As String
+        Try
+            Dim path = ResolveHelpPath()
+            Return $"Справка используется отсюда: {path}"
+        Catch ex As Exception
+            Return ex.Message
+        End Try
+    End Function
+
+    ''' <summary>
+    ''' Открывает файл справки, гарантируя, что он читается без ошибок доступа.
+    ''' </summary>
+    Public Shared Sub ShowHelp(owner As IWin32Window)
+        Dim path = ResolveHelpPath()
+        Help.ShowHelp(owner, path)
+    End Sub
+
+    Private Shared Sub EnsureReadable(path As String)
+        Try
+            Using File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
+            End Using
+        Catch ex As UnauthorizedAccessException
+            Throw New UnauthorizedAccessException($"Нет доступа к файлу справки: {path}", ex)
+        End Try
+    End Sub
+End Class

--- a/Scalemon.UI/Scalemon.UI.vbproj
+++ b/Scalemon.UI/Scalemon.UI.vbproj
@@ -86,6 +86,7 @@
       <DependentUpon>Form1.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="FormHelp.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
## Summary
- add a FormHelp helper that resolves the help file from the application folder before %AppData% and validates read access
- display the resolved help path on the main form and show clearer errors when help cannot be opened
- include the new helper in the UI project

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937be8bfd48832fbfedb8da7ea44a5d)